### PR TITLE
ApkStore

### DIFF
--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/gcloud/GcsPath.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/gcloud/GcsPath.kt
@@ -21,9 +21,40 @@ import com.google.cloud.storage.BlobInfo
 /**
  * Represents the unique path of a Google Cloud Storage object.
  */
-data class GcsPath(val path: String) {
+class GcsPath(path: String) {
+    init {
+        check(path.startsWith("gs://")) {
+            "Invalid Google Cloud Storage path: $path"
+        }
+    }
+    val path = path.trim {
+        it == '/'
+    }
+
+    operator fun plus(other: String): GcsPath {
+        val trimmed = other.trim {
+            it == '/'
+        }
+        return GcsPath("$path/$trimmed")
+    }
+
     override fun toString(): String {
         return path
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as GcsPath
+
+        if (path != other.path) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return path.hashCode()
     }
 
     companion object {

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/ApkStore.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/ApkStore.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.testRunner
+
+import dev.androidx.ci.gcloud.GoogleCloudApi
+import dev.androidx.ci.testRunner.vo.ApkInfo
+import dev.androidx.ci.testRunner.vo.UploadedApk
+import org.apache.logging.log4j.kotlin.logger
+
+/**
+ * Store for Apks
+ *
+ * This class is the handler between GCP and rest of the code where ApkStore handles uploading new Apks and de-duping
+ * them.
+ */
+internal class ApkStore(
+    private val googleCloudApi: GoogleCloudApi,
+) {
+    private val logger = logger()
+
+    suspend fun uploadApk(
+        name: String,
+        bytes: ByteArray
+    ): UploadedApk {
+        val apkInfo = ApkInfo.create(
+            filePath = name,
+            contents = bytes
+        )
+        val relativePath = apkInfo.gcpRelativePath()
+        logger.info {
+            "checking if apk already exists"
+        }
+        val existing = googleCloudApi.existingFilePath(relativePath)
+        if (existing != null) {
+            logger.info { "apk exists already, returning without re-upload: $existing" }
+            return UploadedApk(
+                gcsPath = existing,
+                apkInfo = apkInfo
+            )
+        }
+        logger.info {
+            "uploading $name to $relativePath"
+        }
+        val gcsPath = googleCloudApi.upload(
+            relativePath = relativePath,
+            bytes = bytes
+        )
+        return UploadedApk(
+            gcsPath = gcsPath,
+            apkInfo = apkInfo
+        ).also {
+            logger.info {
+                "completed uploading apk: $it"
+            }
+        }
+    }
+
+    private fun ApkInfo.gcpRelativePath() = nameWithoutExtension + "-" + this.idHash + ".apk"
+}

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/vo/ApkInfo.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/vo/ApkInfo.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.testRunner.vo
+
+import dev.androidx.ci.util.sha256
+
+/**
+ * Information about an APK file.
+ */
+data class ApkInfo(
+    /**
+     * Path of the ApkFile as seen in the output artifact
+     */
+    val filePath: String,
+    /**
+     * A hash value computed from the contents of the ApkFile. Is good enough to be used as a unique identifier.
+     */
+    val idHash: String
+) {
+    val fileName: String by lazy {
+        filePath.split('/').last()
+    }
+
+    val nameWithoutExtension: String by lazy {
+        filePath.split('.').dropLast(1).joinToString("/")
+    }
+
+    companion object {
+        fun create(
+            filePath: String,
+            contents: ByteArray
+        ) = ApkInfo(
+            filePath = filePath,
+            idHash = sha256(contents)
+        )
+    }
+}

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/vo/UploadedApk.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/vo/UploadedApk.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.testRunner.vo
+
+import dev.androidx.ci.gcloud.GcsPath
+
+/**
+ * Wrapper for an Apk that exists in GCP
+ */
+data class UploadedApk(
+    val gcsPath: GcsPath,
+    val apkInfo: ApkInfo
+)

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/util/HashUtil.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/util/HashUtil.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.util
+
+import okio.ByteString.Companion.toByteString
+
+fun sha256(input: ByteArray): String {
+    return input.toByteString().sha256().base64()
+}

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/ApkStoreTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/ApkStoreTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.testRunner
+
+import com.google.common.truth.Truth.assertThat
+import dev.androidx.ci.fake.FakeGoogleCloudApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class ApkStoreTest {
+    private val gcpApi = FakeGoogleCloudApi()
+    private val apkStore = ApkStore(gcpApi)
+
+    @Test
+    fun upload() = runBlocking<Unit> {
+        val uploaded = apkStore.uploadApk(
+            name = "foo.apk",
+            bytes = byteArrayOf(0, 1, 2, 3)
+        )
+        val artifacts = gcpApi.artifacts()
+        assertThat(gcpApi.uploadCount).isEqualTo(1)
+        assertThat(artifacts).hasSize(1)
+        assertThat(artifacts.values.first()).isEqualTo(byteArrayOf(0, 1, 2, 3))
+        assertThat(uploaded.gcsPath).isEqualTo(
+            artifacts.keys.first()
+        )
+        // try to upload again, should not upload
+        val reUploaded = apkStore.uploadApk(
+            name = "foo.apk",
+            bytes = byteArrayOf(0, 1, 2, 3)
+        )
+        assertThat(gcpApi.uploadCount).isEqualTo(1)
+        assertThat(uploaded).isEqualTo(reUploaded)
+        // try to upload with new content, should upload
+        val newContent = apkStore.uploadApk(
+            name = "foo.apk",
+            bytes = byteArrayOf(3, 4, 5, 6)
+        )
+        assertThat(gcpApi.uploadCount).isEqualTo(2)
+        assertThat(gcpApi.artifacts()).hasSize(2)
+        // new content, should have a different path
+        assertThat(newContent.gcsPath).isNotEqualTo(uploaded.gcsPath)
+        // try to upload with new name, should upload
+        val newName = apkStore.uploadApk(
+            name = "bar.apk",
+            bytes = byteArrayOf(0, 1, 2, 3)
+        )
+        assertThat(gcpApi.uploadCount).isEqualTo(3)
+        assertThat(gcpApi.artifacts()).hasSize(3)
+        assertThat(newName.gcsPath).isNotEqualTo(uploaded.gcsPath)
+    }
+}


### PR DESCRIPTION
This PR adds a new class that is responsible for pushing APKs to GCS.

It is fairly primitive such that it will upload the apk to GCS if it doese not exists.
We use a composite key from apk contents + name to compute a unique key.

I've not tested what happens if GCP uploads race so there is a possibility that
if two runners run at the same time w/ the same APK things might go wrong.
We'll deal with it if that happens. As long as GCP does not consider an Object
exists until it is fully uploaded, it should not be a problem.