### PR TITLE
Add a CLI module to be able to invoke from command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 AndroidXCI/build
 AndroidXCI/lib/build
+AndroidXCI/cli/build
 AndroidXCI/ftlModelBuilder/build
 AndroidXCI/.idea
 **/.idea/**

--- a/AndroidXCI/cli/build.gradle.kts
+++ b/AndroidXCI/cli/build.gradle.kts
@@ -14,13 +14,21 @@
  * limitations under the License.
  */
 
-enableFeaturePreview("VERSION_CATALOGS")
-include(":lib")
-include(":cli")
-pluginManagement {
-    includeBuild("ftlModelBuilder")
-    repositories {
-        gradlePluginPortal()
-        mavenCentral()
-    }
+plugins {
+    `kotlin-dsl`
+    kotlin("jvm")
+    id("org.jlleitschuh.gradle.ktlint")
+    `application`
+}
+
+dependencies {
+    implementation(project(":lib"))
+    implementation(kotlin("stdlib"))
+    implementation(libs.coroutines.core)
+    implementation(libs.clikt)
+    implementation(libs.bundles.log4j)
+}
+
+application {
+    mainClass.set("dev.androidx.ci.cli.MainKt")
 }

--- a/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
+++ b/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.file
+import dev.androidx.ci.testRunner.TestRunner
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.core.appender.FileAppender
+import org.apache.logging.log4j.core.layout.PatternLayout
+import kotlin.system.exitProcess
+
+/**
+ * Command line launcher for test runner.
+ */
+private class Cli : CliktCommand() {
+    val runId: String by option(
+        help = """
+            The workflow run id from Github whose artifacts will be used to run tests.
+            e.g. github.event.workflow_run.id
+        """.trimIndent(),
+    ).required()
+    val githubToken by option(
+        help = """
+            Github access token. Can also be set with ANDROIDX_GITHUB_TOKEN environment variable.
+            e.g. secrets.GITHUB_TOKEN
+            https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret
+        """.trimIndent(),
+        envvar = "ANDROIDX_GITHUB_TOKEN"
+    ).required()
+
+    val gcpServiceAccountKey by option(
+        help = """
+            Google Cloud Service Account credentials (JSON). Can also be set with ANDROIDX_GCLOUD_CREDENTIALS
+            environment variable.
+        """.trimIndent(),
+        envvar = "ANDROIDX_GCLOUD_CREDENTIALS"
+    ).required()
+
+    val outputFolder by option(
+        help = """
+            The output folder where results will be downloaded to as well as logs.
+        """.trimIndent()
+    ).file(canBeFile = false, canBeDir = true).required()
+
+    override fun run() {
+        configureLogger()
+        val result = runBlocking {
+            val testRunner = TestRunner.create(
+                runId = runId,
+                githubToken = githubToken,
+                googleCloudCredentials = gcpServiceAccountKey,
+                ioDispatcher = Dispatchers.IO,
+                outputFolder = outputFolder
+            )
+            testRunner.runTests()
+        }
+        println(result.toJson())
+        if (result.allTestsPassed) {
+            exitProcess(0)
+        } else {
+            exitProcess(1)
+        }
+    }
+
+    /**
+     * Add new logger to log into the output directory.
+     */
+    private fun configureLogger() {
+        val ctx = LogManager.getContext(false) as LoggerContext
+        val config = ctx.configuration
+        val layout = PatternLayout.createDefaultLayout(config)
+        val appender = FileAppender.newBuilder<FileAppender.Builder<*>>()
+            .withFileName(outputFolder.resolve("logs.txt").absolutePath)
+            .withAppend(false)
+            .withImmediateFlush(false)
+            .setName("File")
+            .setLayout(layout)
+            .setIgnoreExceptions(false)
+            .withBufferedIo(false)
+            .withBufferSize(4000)
+            .setConfiguration(config)
+            .build()
+        appender.start()
+        config.rootLogger.addAppender(
+            appender,
+            Level.ALL,
+            null
+        )
+        ctx.updateLoggers(config)
+    }
+}
+
+fun main(args: Array<String>) {
+    Cli().main(args)
+}

--- a/AndroidXCI/gradle/libs.versions.toml
+++ b/AndroidXCI/gradle/libs.versions.toml
@@ -23,6 +23,8 @@ gcloud-storage = { module = "com.google.cloud:google-cloud-storage", version = "
 gcloud-datastore = { module = "com.google.cloud:google-cloud-datastore", version = "1.106.4"}
 log4j-kotlin = { module = "org.apache.logging.log4j:log4j-api-kotlin", version = "1.0.0" }
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version = "2.14.1"}
+clikt = { module = "com.github.ajalt.clikt:clikt", version = "3.2.0"}
+
 [bundles]
 retrofit = ["retrofit-core", "retrofit-converter-moshi", "okhttp-core", "okhttp-logging"]
 

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunner.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunner.kt
@@ -16,6 +16,8 @@
 
 package dev.androidx.ci.testRunner
 
+import com.google.auth.oauth2.ServiceAccountCredentials
+import dev.androidx.ci.config.Config
 import dev.androidx.ci.datastore.DatastoreApi
 import dev.androidx.ci.firebase.FirebaseTestLabApi
 import dev.androidx.ci.gcloud.GoogleCloudApi
@@ -24,11 +26,13 @@ import dev.androidx.ci.github.dto.ArtifactsResponse
 import dev.androidx.ci.github.zipArchiveStream
 import dev.androidx.ci.testRunner.vo.TestResult
 import dev.androidx.ci.testRunner.vo.UploadedApk
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import org.apache.logging.log4j.kotlin.logger
+import java.io.File
 import java.util.concurrent.TimeUnit
 import java.util.zip.ZipEntry
 
@@ -57,6 +61,10 @@ class TestRunner(
      * An optional filter to pick which build artifacts should be downloaded.
      */
     private val githubArtifactFilter: ((ArtifactsResponse.Artifact) -> Boolean) = { true },
+    /**
+     * The directory where results will be saved locally
+     */
+    private val outputFolder: File? = null,
 ) {
     private val logger = logger()
     private val testMatrixStore = TestMatrixStore(
@@ -100,10 +108,12 @@ class TestRunner(
             TestResult.IncompleteRun(th.stackTraceToString())
         }
         logger.trace("done running tests, will upload result to gcloud")
+        val resultJson = result.toJson().toByteArray(Charsets.UTF_8)
         googleCloudApi.upload(
             "final-results/$runId/testResult.json",
-            result.toJson().toByteArray(Charsets.UTF_8)
+            resultJson
         )
+        outputFolder?.resolve("result.json")?.writeBytes(resultJson)
         return result
     }
 
@@ -127,5 +137,53 @@ class TestRunner(
             name = zipEntry.name,
             bytes = bytes
         )
+    }
+
+    companion object {
+        fun create(
+            runId: String,
+            githubToken: String,
+            googleCloudCredentials: String,
+            ioDispatcher: CoroutineDispatcher,
+            outputFolder: File?
+        ): TestRunner {
+            val credentials = ServiceAccountCredentials.fromStream(
+                googleCloudCredentials.byteInputStream(Charsets.UTF_8)
+            )
+            return TestRunner(
+                googleCloudApi = GoogleCloudApi.build(
+                    Config.GCloud(
+                        credentials = credentials,
+                        bucketName = "androidx-ftl-test-results",
+                        bucketPath = "github-ci-action"
+                    ),
+                    context = ioDispatcher
+                ),
+                githubApi = GithubApi.build(
+                    Config.Github(
+                        owner = "androidX",
+                        repo = "androidx",
+                        token = githubToken
+                    )
+                ),
+                firebaseTestLabApi = FirebaseTestLabApi.build(
+                    config = Config.FirebaseTestLab(
+                        credentials = credentials
+                    )
+                ),
+                firebaseProjectId = "androidx-dev-prod",
+                datastoreApi = DatastoreApi.build(
+                    Config.Datastore(
+                        credentials = credentials
+                    ),
+                    context = ioDispatcher
+                ),
+                githubArtifactFilter = {
+                    it.name.contains("artifacts_room")
+                },
+                outputFolder = outputFolder,
+                runId = runId
+            )
+        }
     }
 }

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/vo/TestResult.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/vo/TestResult.kt
@@ -68,6 +68,6 @@ sealed class TestResult(
             )
             .addLast(MetadataKotlinJsonAdapterFactory())
             .build()
-        private val adapter = moshi.adapter(TestResult::class.java).lenient()
+        private val adapter = moshi.adapter(TestResult::class.java).indent("  ").lenient()
     }
 }

--- a/AndroidXCI/lib/src/main/resources/log4j2.properties
+++ b/AndroidXCI/lib/src/main/resources/log4j2.properties
@@ -16,7 +16,7 @@
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d %p [%t] %m%n
+appender.console.layout.pattern = %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
 
 rootLogger.level = info
 rootLogger.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
During development, we probably just want to use ./gradlew run --args and once
it is more or less stable, we can consider creating a dist to avoid recompiling it.

This setup supports both.