### PR TITLE
Report status for the head commit

### DIFF
--- a/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
+++ b/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
@@ -35,12 +35,20 @@ import kotlin.system.exitProcess
  * Command line launcher for test runner.
  */
 private class Cli : CliktCommand() {
-    val runId: String by option(
+    val targetRunId: String by option(
         help = """
             The workflow run id from Github whose artifacts will be used to run tests.
             e.g. github.event.workflow_run.id
         """.trimIndent(),
-        envvar = "ANDROIDX_RUN_ID"
+        envvar = "ANDROIDX_TARGET_RUN_ID"
+    ).required()
+    val hostRunId: String by option(
+        help = """
+            The workflow run id from Github which is running these tests right now.
+            Will be useful to construct urls for results:
+            e.g. github.run_id
+        """.trimIndent(),
+        envvar = "ANDROIDX_HOST_RUN_ID"
     ).required()
     val githubToken by option(
         help = """
@@ -84,7 +92,8 @@ private class Cli : CliktCommand() {
         val githubRepo = repoParts.drop(1).joinToString("/")
         val result = runBlocking {
             val testRunner = TestRunner.create(
-                runId = runId,
+                targetRunId = targetRunId,
+                hostRunId = hostRunId,
                 githubToken = githubToken,
                 googleCloudCredentials = gcpServiceAccountKey,
                 ioDispatcher = Dispatchers.IO,

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/github/GithubApi.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/github/GithubApi.kt
@@ -19,12 +19,16 @@ package dev.androidx.ci.github
 import com.squareup.moshi.Moshi
 import dev.androidx.ci.config.Config
 import dev.androidx.ci.github.dto.ArtifactsResponse
+import dev.androidx.ci.github.dto.CommitInfo
+import dev.androidx.ci.github.dto.RunInfo
 import dev.zacsweers.moshix.reflect.MetadataKotlinJsonAdapterFactory
 import okhttp3.OkHttpClient
 import okhttp3.ResponseBody
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Url
 import java.util.concurrent.TimeUnit
@@ -47,6 +51,27 @@ interface GithubApi {
      */
     @GET
     suspend fun zipArchive(@Url path: String): ResponseBody
+
+    /**
+     * Returns the data about a github workflow run
+     */
+    @GET("actions/runs/{runId}")
+    suspend fun runInfo(@Path("runId") runId: String): RunInfo
+
+    /**
+     * Returns the status of a commit.
+     */
+    @GET("commits/{ref}/status")
+    suspend fun commitStatus(@Path("ref") ref: String): CommitInfo
+
+    /**
+     * Updates the status for a commit. You can use this endpoint to associate test runs with a particular commit / PR.
+     */
+    @POST("statuses/{sha}")
+    suspend fun updateCommitStatus(
+        @Path("sha") sha: String,
+        @Body update: CommitInfo.Update
+    ): CommitInfo.Status
 
     companion object {
         fun build(

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/github/dto/CommitInfo.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/github/dto/CommitInfo.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.github.dto
+
+import com.squareup.moshi.Json
+
+/**
+ * Details of a git commit
+ */
+data class CommitInfo(
+    /**
+     * The commit sha
+     */
+    val sha: String,
+    /**
+     * The state of the commit based on [statuses]
+     */
+    val state: State,
+    /**
+     * Individual status reports for the commit.
+     */
+    val statuses: List<Status>
+) {
+    data class Status(
+        val url: String,
+        val id: String,
+        val state: State,
+        val description: String?,
+        @Json(name = "target_url")
+        val targetUrl: String?,
+        val context: String?
+    )
+    enum class State {
+        @Json(name = "error")
+        ERROR,
+        @Json(name = "failure")
+        FAILURE,
+        @Json(name = "pending")
+        PENDING,
+        @Json(name = "success")
+        SUCCESS,
+    }
+
+    data class Update(
+        val state: State,
+        /**
+         * The url which will be linked from the Github UI
+         */
+        @Json(name = "target_url")
+        val targetUrl: String,
+        /**
+         * Some description of what happened
+         */
+        val description: String,
+        /**
+         * The context for this check. This is like the ID of the status, should usually be the same for the same type
+         * of check.
+         */
+        val context: String
+    )
+}

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/github/dto/RunInfo.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/github/dto/RunInfo.kt
@@ -24,6 +24,7 @@ import com.squareup.moshi.Json
 data class RunInfo(
     val id: String,
     val name: String,
+    @Json(name = "html_url")
     val url: String,
     @Json(name = "head_sha")
     val headSha: String,

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/github/dto/RunInfo.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/github/dto/RunInfo.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.github.dto
+
+import com.squareup.moshi.Json
+
+/**
+ * Information about a Github Workflow run from which we can find related commits, PRs etc.
+ */
+data class RunInfo(
+    val id: String,
+    val name: String,
+    val url: String,
+    @Json(name = "head_sha")
+    val headSha: String,
+)

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/StatusReporter.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/StatusReporter.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.testRunner
+
+import dev.androidx.ci.github.GithubApi
+import dev.androidx.ci.github.dto.CommitInfo
+import dev.androidx.ci.github.dto.RunInfo
+import dev.androidx.ci.testRunner.vo.TestResult
+import dev.androidx.ci.util.LazyComputedValue
+
+/**
+ * Helper class to report status of a run to the backend, github etc.
+ */
+class StatusReporter(
+    val githubApi: GithubApi,
+    /**
+     * The Github workflow run which is hosting this TestRun
+     */
+    val hostRunId: String,
+    /**
+     * The Github workflow whose artifacts are being tested
+     */
+    val targetRunId: String
+) {
+    private val targetRunInfo = LazyComputedValue<RunInfo> {
+        githubApi.runInfo(targetRunId)
+    }
+
+    private val hostRunInfo = LazyComputedValue<RunInfo> {
+        githubApi.runInfo(hostRunId)
+    }
+
+    suspend fun reportStart() {
+        updateState(CommitInfo.State.PENDING)
+    }
+
+    suspend fun reportEnd(testResult: TestResult) {
+        val newState = when {
+            testResult is TestResult.IncompleteRun -> CommitInfo.State.ERROR
+            testResult.allTestsPassed -> CommitInfo.State.SUCCESS
+            else -> CommitInfo.State.FAILURE
+        }
+        updateState(state = newState)
+    }
+
+    private suspend fun updateState(
+        state: CommitInfo.State
+    ) {
+        val targetRunInfo = targetRunInfo.get()
+        val hostRunInfo = hostRunInfo.get()
+        githubApi.updateCommitStatus(
+            sha = targetRunInfo.headSha,
+            update = CommitInfo.Update(
+                state = state,
+                // the url for results is the url of the host run
+                targetUrl = hostRunInfo.url,
+                description = DESCRIPTION,
+                context = CONTEXT
+            )
+        )
+    }
+
+    companion object {
+        const val DESCRIPTION = "Integration Tests"
+        const val CONTEXT = "AndroidX-FTL"
+    }
+}

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/util/LazyComputedValue.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/util/LazyComputedValue.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.sync.withLock
 
 @Suppress("UNCHECKED_CAST")
 class LazyComputedValue<T>(
-    val compute: suspend () -> T
+    private val compute: suspend () -> T
 ) {
     private var computed: Any? = NOT_COMPUTED
     private val mutex = Mutex()

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeBackend.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeBackend.kt
@@ -18,6 +18,7 @@ package dev.androidx.ci.fake
 
 import dev.androidx.ci.generated.ftl.TestMatrix
 import dev.androidx.ci.github.dto.ArtifactsResponse
+import dev.androidx.ci.github.dto.RunInfo
 import java.util.UUID
 import kotlin.random.Random
 
@@ -30,11 +31,11 @@ class FakeBackend(
     randomSeed: Long = -1
 ) {
     private val random = Random(randomSeed)
-    fun createRun(runId: String, artifacts: List<ArtifactsResponse.Artifact>) {
+    fun createRun(runId: String, artifacts: List<ArtifactsResponse.Artifact>): RunInfo {
         val response = ArtifactsResponse(
             artifacts = artifacts
         )
-        fakeGithubApi.putArtifact(runId, response)
+        return fakeGithubApi.putArtifact(runId, response)
     }
 
     fun finishAllTests(

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeGithubApi.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeGithubApi.kt
@@ -18,21 +18,44 @@ package dev.androidx.ci.fake
 
 import dev.androidx.ci.github.GithubApi
 import dev.androidx.ci.github.dto.ArtifactsResponse
+import dev.androidx.ci.github.dto.CommitInfo
+import dev.androidx.ci.github.dto.RunInfo
 import okhttp3.ResponseBody
 import okhttp3.internal.http.RealResponseBody
 import okio.Buffer
+import java.util.UUID
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 class FakeGithubApi : GithubApi {
+    private val runInfos = mutableMapOf<String, RunInfo>()
+    private val commitInfos = mutableMapOf<String, CommitInfo>()
     private val artifacts = mutableMapOf<String, ArtifactsResponse>()
     private val zipArchives = mutableMapOf<String, ResponseBody>()
+
+    private fun getOrCreateRunInfo(runId: String): RunInfo {
+        return runInfos.getOrPut(runId) {
+            val sha = UUID.randomUUID().toString()
+            commitInfos[sha] = CommitInfo(
+                sha = sha,
+                state = CommitInfo.State.PENDING,
+                statuses = emptyList()
+            )
+            RunInfo(
+                id = runId,
+                name = "test-run",
+                url = "https://test/run/$runId",
+                headSha = sha
+            )
+        }
+    }
 
     fun putArtifact(
         runId: String,
         response: ArtifactsResponse
     ) {
-        artifacts[runId] = response
+        val runInfo = getOrCreateRunInfo(runId)
+        artifacts[runInfo.id] = response
     }
 
     fun putArchive(
@@ -69,5 +92,33 @@ class FakeGithubApi : GithubApi {
 
     override suspend fun zipArchive(path: String): ResponseBody {
         return zipArchives[path] ?: throwNotFound<ResponseBody>()
+    }
+
+    override suspend fun runInfo(runId: String): RunInfo {
+        return runInfos[runId] ?: throwNotFound<RunInfo>()
+    }
+
+    override suspend fun commitStatus(ref: String): CommitInfo {
+        return commitInfos[ref] ?: throwNotFound<CommitInfo>()
+    }
+
+    override suspend fun updateCommitStatus(sha: String, update: CommitInfo.Update): CommitInfo.Status {
+        val commitInfo = commitInfos[sha] ?: throwNotFound<CommitInfo.Status>()
+        val newStatus = CommitInfo.Status(
+            url = "https://status/$sha",
+            id = UUID.randomUUID().toString(),
+            description = update.description,
+            state = update.state,
+            targetUrl = update.targetUrl,
+            context = update.targetUrl
+        )
+        val combinedStatuses = (listOf(newStatus) + commitInfo.statuses).distinctBy {
+            it.context
+        }
+        commitInfos[sha] = commitInfo.copy(
+            statuses = combinedStatuses,
+            state = combinedStatuses.minByOrNull { it.state }?.state ?: CommitInfo.State.PENDING
+        )
+        return newStatus
     }
 }

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeGithubApi.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeGithubApi.kt
@@ -53,9 +53,10 @@ class FakeGithubApi : GithubApi {
     fun putArtifact(
         runId: String,
         response: ArtifactsResponse
-    ) {
+    ): RunInfo {
         val runInfo = getOrCreateRunInfo(runId)
         artifacts[runInfo.id] = response
+        return runInfo
     }
 
     fun putArchive(
@@ -110,7 +111,7 @@ class FakeGithubApi : GithubApi {
             description = update.description,
             state = update.state,
             targetUrl = update.targetUrl,
-            context = update.targetUrl
+            context = update.context
         )
         val combinedStatuses = (listOf(newStatus) + commitInfo.statuses).distinctBy {
             it.context

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/StateReporterTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/StateReporterTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.testRunner
+
+import com.google.common.truth.Truth.assertThat
+import dev.androidx.ci.fake.FakeBackend
+import dev.androidx.ci.generated.ftl.EnvironmentMatrix
+import dev.androidx.ci.generated.ftl.GoogleCloudStorage
+import dev.androidx.ci.generated.ftl.ResultStorage
+import dev.androidx.ci.generated.ftl.TestMatrix
+import dev.androidx.ci.generated.ftl.TestSpecification
+import dev.androidx.ci.github.dto.CommitInfo
+import dev.androidx.ci.github.dto.CommitInfo.State.PENDING
+import dev.androidx.ci.github.dto.CommitInfo.State.SUCCESS
+import dev.androidx.ci.github.dto.RunInfo
+import dev.androidx.ci.testRunner.vo.TestResult
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class StateReporterTest {
+    private val fakeBackend = FakeBackend()
+    private val reporter = StatusReporter(
+        githubApi = fakeBackend.fakeGithubApi,
+        hostRunId = HOST_RUN_ID,
+        targetRunId = TARGET_RUN_ID
+    )
+    private val targetRunInfo: RunInfo = fakeBackend.createRun(TARGET_RUN_ID, emptyList())
+    private val hostRunInfo: RunInfo = fakeBackend.createRun(HOST_RUN_ID, emptyList())
+
+    @Test
+    fun reportStart() = runBlocking<Unit> {
+        reporter.reportStart()
+        val status = fakeBackend.fakeGithubApi.commitStatus(targetRunInfo.headSha)
+        assertThat(
+            status.statuses
+        ).hasSize(1)
+        assertThat(
+            status.state
+        ).isEqualTo(PENDING)
+        status.statuses.first().let {
+            assertThat(it.context).isEqualTo(StatusReporter.CONTEXT)
+            assertThat(it.description).isEqualTo(StatusReporter.DESCRIPTION)
+            assertThat(it.state).isEqualTo(PENDING)
+            assertThat(it.targetUrl).isEqualTo(hostRunInfo.url)
+        }
+    }
+
+    @Test
+    fun reportEnd_success() = runBlocking<Unit> {
+        reporter.reportEnd(
+            TestResult.CompleteRun(matrices = emptyList())
+        )
+        val status = fakeBackend.fakeGithubApi.commitStatus(targetRunInfo.headSha).statuses.first()
+        assertThat(
+            status.state
+        ).isEqualTo(SUCCESS)
+    }
+
+    @Test
+    fun reportEnd_fail() = runBlocking<Unit> {
+        val matrix = TestMatrix(
+            resultStorage = ResultStorage(
+                googleCloudStorage = GoogleCloudStorage("gs://fake-path")
+            ),
+            projectId = "myProject",
+            environmentMatrix = EnvironmentMatrix(),
+            testSpecification = TestSpecification()
+        )
+        val failedTestMatrix = fakeBackend.fakeFirebaseTestLabApi.createTestMatrix(
+            projectId = "myProject",
+            requestId = "requestId",
+            testMatrix = matrix
+        )
+        reporter.reportEnd(
+            TestResult.CompleteRun(matrices = listOf(failedTestMatrix))
+        )
+        val status = fakeBackend.fakeGithubApi.commitStatus(targetRunInfo.headSha).statuses.first()
+        assertThat(
+            status.state
+        ).isEqualTo(CommitInfo.State.FAILURE)
+    }
+
+    @Test
+    fun reportEnd_error() = runBlocking<Unit> {
+        reporter.reportEnd(
+            TestResult.IncompleteRun("some error")
+        )
+        val status = fakeBackend.fakeGithubApi.commitStatus(targetRunInfo.headSha).statuses.first()
+        assertThat(
+            status.state
+        ).isEqualTo(CommitInfo.State.ERROR)
+    }
+
+    companion object {
+        const val HOST_RUN_ID = "1"
+        const val TARGET_RUN_ID = "2"
+    }
+}

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerPlayground.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerPlayground.kt
@@ -81,7 +81,8 @@ class TestRunnerPlayground {
             githubArtifactFilter = {
                 it.name.contains("artifacts_room")
             },
-            runId = runId
+            targetRunId = runId,
+            hostRunId = runId
         )
     }
 

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'Run Integration Tests'
 description: 'This action runs integration tests from the outputs of a given workflow run'
 inputs:
-  run-id:
+  run-id: # TODO: migrate to target-run-id once we start versioning AndroidX
     description: 'The github run id whose artifacts will be tested'
     required: true
   gcp-token:
@@ -21,5 +21,6 @@ runs:
       env:
         ANDROIDX_GITHUB_TOKEN: ${{ inputs.github-token }}
         ANDROIDX_GCLOUD_CREDENTIALS: ${{ inputs.gcp-token }}
-        ANDROIDX_RUN_ID: ${{ inputs.run-id }}
+        ANDROIDX_TARGET_RUN_ID: ${{ inputs.run-id }}
+        ANDROIDX_HOST_RUN_ID: ${{ github.run_id }}
         ANDROIDX_OUTPUT_FOLDER: ${{ inputs.output-folder }}

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
 name: 'Run Integration Tests'
 description: 'This action runs integration tests from the outputs of a given workflow run'
 inputs:
-  run-id: # TODO: migrate to target-run-id once we start versioning AndroidX
-    description: 'The github run id whose artifacts will be tested'
-    required: true
+  target-run-id:
+    description: 'The github run id whose artifacts will be tested. Defaults to github.event.workflow_run.id'
+    required: false
   gcp-token:
     description: 'Google Cloud Platform service account token (in json)'
     required: true
@@ -21,6 +21,6 @@ runs:
       env:
         ANDROIDX_GITHUB_TOKEN: ${{ inputs.github-token }}
         ANDROIDX_GCLOUD_CREDENTIALS: ${{ inputs.gcp-token }}
-        ANDROIDX_TARGET_RUN_ID: ${{ inputs.run-id }}
+        ANDROIDX_TARGET_RUN_ID: ${{ github.event.workflow_run.id || inputs.target-run-id }}
         ANDROIDX_HOST_RUN_ID: ${{ github.run_id }}
         ANDROIDX_OUTPUT_FOLDER: ${{ inputs.output-folder }}


### PR DESCRIPTION
This PR adds functionality to associate commit status with the head commit.

Github shows these statuses in the PR UI so we can observe test results there.