### PR TITLE
Add retry functionality to rest apis

### DIFF
--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/firebase/FirebaseTestLabApi.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/firebase/FirebaseTestLabApi.kt
@@ -21,6 +21,8 @@ import dev.androidx.ci.config.Config
 import dev.androidx.ci.firebase.dto.EnvironmentType
 import dev.androidx.ci.generated.ftl.TestEnvironmentCatalog
 import dev.androidx.ci.generated.ftl.TestMatrix
+import dev.androidx.ci.util.Retry
+import dev.androidx.ci.util.RetryCallAdapterFactory
 import dev.zacsweers.moshix.reflect.MetadataKotlinJsonAdapterFactory
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -32,6 +34,7 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface FirebaseTestLabApi {
+    @Retry
     @GET("projects/{projectId}/testMatrices/{testMatrixId}")
     suspend fun getTestMatrix(
         @Path("projectId") projectId: String,
@@ -45,6 +48,7 @@ interface FirebaseTestLabApi {
         @Body testMatrix: TestMatrix
     ): TestMatrix
 
+    @Retry
     @GET("testEnvironmentCatalog/{environmentType}")
     suspend fun getTestEnvironmentCatalog(
         @Path("environmentType") environmentType: EnvironmentType,
@@ -74,6 +78,7 @@ interface FirebaseTestLabApi {
                 .client(client)
                 .baseUrl(config.endPoint)
                 .addConverterFactory(MoshiConverterFactory.create(moshi).asLenient())
+                .addCallAdapterFactory(RetryCallAdapterFactory.GLOBAL)
                 .build()
                 .create(FirebaseTestLabApi::class.java)
         }

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/util/RetrofitExt.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/util/RetrofitExt.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.util
+
+import okhttp3.Request
+import okio.Timeout
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Callback
+import retrofit2.Response
+import retrofit2.Retrofit
+import java.lang.reflect.Type
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Target(AnnotationTarget.FUNCTION)
+annotation class Retry(val times: Int)
+typealias RetryScheduler = (delay: Long, timeUnit: TimeUnit, block: suspend () -> Unit) -> Unit
+
+private class RetryCallAdapter(
+    val scheduler: RetryScheduler,
+    val delegate: CallAdapter<Any?, Any?>,
+    val retry: Int,
+) : CallAdapter<Any?, Any?> {
+    override fun responseType(): Type {
+        return delegate.responseType()
+    }
+
+    override fun adapt(call: Call<Any?>): Any {
+        return RetryCall(scheduler, delegate.adapt(call) as Call<Any?>, retry)
+    }
+}
+
+private class RetryCall(
+    private val scheduler: RetryScheduler,
+    private var delegate: Call<Any?>,
+    private val retryLimit: Int
+) : Call<Any?> {
+    private val cancelled = AtomicBoolean(false)
+    private var retryCount = 0
+    override fun clone(): Call<Any?> {
+        return RetryCall(scheduler, delegate.clone(), retryLimit)
+    }
+
+    override fun execute(): Response<Any?> {
+        error("sync ops are not supported yet")
+    }
+
+    override fun enqueue(callback: Callback<Any?>) {
+        if (isCanceled || isExecuted) {
+            return
+        }
+        delegate.enqueue(
+            RetryCallback(
+                delegate = callback,
+                shouldRetry = { response: Response<Any?>? ->
+                    retryCount < retryLimit && (
+                        response == null || response.code() >= 500
+                        )
+                },
+                retry = {
+                    retry(callback)
+                }
+            )
+        )
+    }
+
+    private fun retry(callback: Callback<Any?>) {
+        retryCount ++
+        val delaySeconds = minOf(10, retryCount * 2).toLong() // 1 4 9 10 10 10 ...
+        delegate = delegate.clone()
+        scheduler(
+            delaySeconds,
+            TimeUnit.SECONDS
+        ) {
+            enqueue(callback)
+        }
+    }
+
+    override fun isExecuted(): Boolean {
+        return delegate.isExecuted
+    }
+
+    override fun cancel() {
+        cancelled.set(true)
+        delegate.cancel()
+    }
+
+    override fun isCanceled(): Boolean {
+        return cancelled.get() || delegate.isCanceled
+    }
+
+    override fun request(): Request {
+        return delegate.request()
+    }
+
+    override fun timeout(): Timeout {
+        return delegate.timeout()
+    }
+}
+
+private class RetryCallback(
+    val delegate: Callback<Any?>,
+    val shouldRetry: (Response<Any?>?) -> Boolean,
+    val retry: () -> Unit
+) : Callback<Any?> {
+    override fun onResponse(call: Call<Any?>, response: Response<Any?>) {
+        if (shouldRetry(response)) {
+            retry()
+        } else {
+            delegate.onResponse(call, response)
+        }
+    }
+
+    override fun onFailure(call: Call<Any?>, t: Throwable) {
+        if (shouldRetry(null)) {
+            retry()
+        } else {
+            delegate.onFailure(call, t)
+        }
+    }
+}
+
+class RetryCallAdapterFactory(
+    private val scheduler: RetryScheduler
+) : CallAdapter.Factory() {
+    override fun get(returnType: Type, annotations: Array<out Annotation>, retrofit: Retrofit): CallAdapter<*, *> {
+        val annotation = annotations.firstOrNull() {
+            it.annotationClass == Retry::class
+        } as? Retry
+        val delegate = retrofit.nextCallAdapter(
+            this,
+            returnType,
+            annotations
+        )
+        if (annotation == null) {
+            return delegate
+        } else {
+            return RetryCallAdapter(
+                scheduler = scheduler,
+                delegate = delegate as CallAdapter<Any?, Any?>,
+                retry = annotation.times
+            )
+        }
+    }
+}

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/github/GithubApiTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/github/GithubApiTest.kt
@@ -40,6 +40,9 @@ class GithubApiTest {
     @Test
     fun artifacts() {
         mockWebServer.enqueue(
+            MockResponse().setResponseCode(505) // fail first, should retry
+        )
+        mockWebServer.enqueue(
             MockResponse().setBody(
                 ARTIFACTS_RESPONSE
             )

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/util/RetryCallAdapterTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/util/RetryCallAdapterTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.util
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.moshi.Moshi
+import dev.zacsweers.moshix.reflect.MetadataKotlinJsonAdapterFactory
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.junit.Before
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.http.GET
+import java.util.concurrent.TimeUnit
+
+/**
+ * This test is ugly as it uses real time and might flake.
+ * Unfortunately, MockWebServer does not provide an api to control time or respond to requests asynchronously. (creates
+ * its own thread).
+ *
+ * This is good enough for now, if it flakes etc, we'll figure out a solution.
+ */
+class RetryCallAdapterTest {
+    private val server = MockWebServer()
+    interface Api {
+        @Retry(2)
+        @GET("foo")
+        suspend fun retry2(): Response
+    }
+
+    private fun enqueueResponse(responseCode: Int) {
+        if (responseCode == 200) {
+            server.enqueue(
+                MockResponse().setBody(TEST_DATA_JSON)
+            )
+        } else {
+            server.enqueue(
+                MockResponse().setResponseCode(responseCode)
+            )
+        }
+    }
+
+    lateinit var api: Api
+
+    @Before
+    fun init() {
+        val moshi = Moshi.Builder()
+            .add(MetadataKotlinJsonAdapterFactory())
+            .build()
+        val client = OkHttpClient.Builder()
+            .callTimeout(1, TimeUnit.SECONDS)
+            .build()
+        api = Retrofit.Builder()
+            .addCallAdapterFactory(
+                RetryCallAdapterFactory { time, unit, callback ->
+                    GlobalScope.launch {
+                        delay(TEST_DELAY)
+                        callback()
+                    }
+                }
+            )
+            .client(client)
+            .addConverterFactory(MoshiConverterFactory.create(moshi).asLenient())
+            .baseUrl(server.url("/"))
+            .build()
+            .create(Api::class.java)
+    }
+
+    @Test
+    fun dontRetryOnClientError() = runBlocking<Unit> {
+        enqueueResponse(404)
+        val result = runCatching {
+            api.retry2()
+        }
+        assertThat(result.isFailure).isTrue()
+        assertThat((result.exceptionOrNull() as? HttpException)?.code()).isEqualTo(404)
+        assertThat(server.requestCount).isEqualTo(1)
+    }
+
+    @Test
+    fun dontRetryOnSuccess() = runBlocking<Unit> {
+        enqueueResponse(200)
+        val result = api.retry2()
+        assertThat(result).isEqualTo(TEST_DATA)
+        assertThat(server.requestCount).isEqualTo(1)
+    }
+
+    @Test
+    fun simple() = runBlocking<Unit> {
+        enqueueResponse(500)
+        enqueueResponse(501)
+        enqueueResponse(200)
+        val data = api.retry2()
+        assertThat(data).isEqualTo(TEST_DATA)
+        assertThat(server.requestCount).isEqualTo(3)
+    }
+
+    @Test
+    fun connectionError() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
+        enqueueResponse(500)
+        enqueueResponse(200)
+        val data = api.retry2()
+        assertThat(data).isEqualTo(TEST_DATA)
+        assertThat(server.requestCount).isEqualTo(3)
+    }
+
+    @Test
+    fun cancelledCall() = runBlocking<Unit> {
+        server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
+        enqueueResponse(500)
+        enqueueResponse(200)
+        val call = async {
+            api.retry2()
+        }
+        delay(500)
+        call.cancelAndJoin()
+        delay(TEST_DELAY * 2) // wait for retry call
+        assertThat(server.requestCount).isEqualTo(1)
+    }
+
+    @Test
+    fun cancelledCall_duringRetry() = runBlocking<Unit> {
+        enqueueResponse(500)
+        enqueueResponse(500)
+        enqueueResponse(200)
+        val call = async {
+            api.retry2()
+        }
+        delay(TEST_DELAY + TEST_DELAY / 2) // for retry
+        call.cancelAndJoin()
+        delay(TEST_DELAY * 2) // wait for retry call
+        assertThat(server.requestCount).isEqualTo(2)
+    }
+
+    data class Response(
+        val a: String,
+        val b: String
+    )
+
+    companion object {
+        private val TEST_DATA = Response(
+            a = "abc",
+            b = "cde"
+        )
+        private val TEST_DATA_JSON = """{ "a" : "abc", "b" :"cde" }"""
+        private val TEST_DELAY = TimeUnit.SECONDS.toMillis(1)
+    }
+}


### PR DESCRIPTION
Retrofit already retries connection errors so this is only for server errors.