### PR TITLE
Add support for running integration tests for libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ AndroidXCI/build
 AndroidXCI/lib/build
 AndroidXCI/cli/build
 AndroidXCI/ftlModelBuilder/build
+AndroidXCI/placeholderapp/build
 AndroidXCI/.idea
 **/.idea/**
 **/.gradle/**

--- a/AndroidXCI/build.gradle.kts
+++ b/AndroidXCI/build.gradle.kts
@@ -27,11 +27,13 @@ version = "1.0-SNAPSHOT"
 
 repositories {
     mavenCentral()
+    google()
 }
 
 subprojects {
     repositories {
         mavenCentral()
+        google()
     }
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java).configureEach {
         kotlinOptions {

--- a/AndroidXCI/ftlModelBuilder/src/main/kotlin/dev/androidx/ci/codegen/plugin/GenerateModelsPlugin.kt
+++ b/AndroidXCI/ftlModelBuilder/src/main/kotlin/dev/androidx/ci/codegen/plugin/GenerateModelsPlugin.kt
@@ -44,8 +44,7 @@ class GenerateModelsPlugin : Plugin<Project> {
 
         generateModelsTaskProvider.configure { task ->
             task.description = "Generate models"
-            task.discoveryFileUrl.set(extension.discoveryFileUrl)
-            task.pkg.set(extension.pkg)
+            task.models.set(extension.models)
             task.sourceOutDir.set(
                 target.layout.buildDirectory.dir("generatedModels")
             )

--- a/AndroidXCI/ftlModelBuilder/src/main/kotlin/dev/androidx/ci/codegen/plugin/GenerateModelsTask.kt
+++ b/AndroidXCI/ftlModelBuilder/src/main/kotlin/dev/androidx/ci/codegen/plugin/GenerateModelsTask.kt
@@ -19,7 +19,7 @@ package dev.androidx.ci.codegen.plugin
 import dev.androidx.ci.codegen.DiscoveryDocumentModelGenerator
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.provider.Property
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
@@ -31,10 +31,7 @@ import org.gradle.api.tasks.TaskAction
 @CacheableTask
 internal abstract class GenerateModelsTask : DefaultTask() {
     @get:Input
-    abstract val discoveryFileUrl: Property<String>
-
-    @get:Input
-    abstract val pkg: Property<String>
+    abstract val models: ListProperty<GeneratedModelInfo>
 
     @get:OutputDirectory
     abstract val sourceOutDir: DirectoryProperty
@@ -43,10 +40,12 @@ internal abstract class GenerateModelsTask : DefaultTask() {
     fun generateModels() {
         val outDir = sourceOutDir.asFile.get()
         outDir.deleteRecursively()
-        DiscoveryDocumentModelGenerator(
-            outDir = outDir,
-            discoveryUrl = discoveryFileUrl.get(),
-            pkg = pkg.get()
-        ).generate()
+        models.get().forEach { input ->
+            DiscoveryDocumentModelGenerator(
+                outDir = outDir,
+                discoveryUrl = input.discoveryFileUrl,
+                pkg = input.pkg
+            ).generate()
+        }
     }
 }

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/config/Config.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/config/Config.kt
@@ -46,4 +46,8 @@ class Config {
     class Datastore(
         val credentials: Credentials,
     )
+    class ToolsResult(
+        val endPoint: String = "https://toolresults.googleapis.com/toolresults/v1beta3/",
+        val credentials: Credentials
+    )
 }

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/firebase/ToolsResultApi.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/firebase/ToolsResultApi.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.firebase
+
+import com.squareup.moshi.Moshi
+import dev.androidx.ci.config.Config
+import dev.androidx.ci.generated.testResults.History
+import dev.androidx.ci.generated.testResults.ListHistoriesResponse
+import dev.androidx.ci.util.Retry
+import dev.androidx.ci.util.RetryCallAdapterFactory
+import dev.zacsweers.moshix.reflect.MetadataKotlinJsonAdapterFactory
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface ToolsResultApi {
+    @Retry
+    @GET("projects/{projectId}/histories")
+    suspend fun getHistories(
+        @Path("projectId") projectId: String,
+        @Query("filterByName") name: String? = null,
+        @Query("pageSize") pageSize: Int = 100
+    ): ListHistoriesResponse
+
+    @Retry
+    @POST("projects/{projectId}/histories")
+    suspend fun create(
+        @Path("projectId") projectId: String,
+        @Query("requestId") requestId: String? = null,
+        @Body history: History
+    ): History
+
+    companion object {
+        fun build(
+            config: Config.ToolsResult
+        ): ToolsResultApi {
+            val client = OkHttpClient.Builder().authenticateWith(config.credentials).addInterceptor {
+                val newBuilder = it.request().newBuilder()
+                newBuilder.addHeader(
+                    "Content-Type", "application/json;charset=utf-8",
+                )
+                newBuilder.addHeader(
+                    "Accept", "application/json"
+                )
+                it.proceed(
+                    newBuilder.build()
+                )
+            }.build()
+            val moshi = Moshi.Builder()
+                .add(MetadataKotlinJsonAdapterFactory())
+                .build()
+            return Retrofit.Builder()
+                .client(client)
+                .baseUrl(config.endPoint)
+                .addConverterFactory(MoshiConverterFactory.create(moshi).asLenient())
+                .addCallAdapterFactory(RetryCallAdapterFactory.GLOBAL)
+                .build()
+                .create(ToolsResultApi::class.java)
+        }
+    }
+}

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/ApkStore.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/ApkStore.kt
@@ -19,6 +19,7 @@ package dev.androidx.ci.testRunner
 import dev.androidx.ci.gcloud.GoogleCloudApi
 import dev.androidx.ci.testRunner.vo.ApkInfo
 import dev.androidx.ci.testRunner.vo.UploadedApk
+import dev.androidx.ci.util.LazyComputedValue
 import org.apache.logging.log4j.kotlin.logger
 
 /**
@@ -31,6 +32,18 @@ class ApkStore(
     private val googleCloudApi: GoogleCloudApi,
 ) {
     private val logger = logger()
+
+    private val placeholderApk = LazyComputedValue<UploadedApk> {
+        val bytes = ApkStore::class.java.getResource("/placeholderApp.apk")?.openStream()?.use {
+            it.readAllBytes()
+        }
+        checkNotNull(bytes) {
+            "Cannot read placeholder apk from resources"
+        }
+        uploadApk("placeholderApp.apk", bytes)
+    }
+
+    suspend fun getPlaceholderApk() = placeholderApk.get()
 
     suspend fun uploadApk(
         name: String,

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/FirebaseTestLabController.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/FirebaseTestLabController.kt
@@ -47,10 +47,10 @@ class FirebaseTestLabController(
         )
         logger.info { "received catalog: $catalog" }
         val defaultModel = catalog.androidDeviceCatalog?.models?.first { model ->
-            model?.tags?.contains("default") == true
+            model.tags?.contains("default") == true
         } ?: error("Cannot find default model in test device catalog:  $catalog")
         val defaultVersion = catalog.androidDeviceCatalog.versions?.first { version ->
-            version?.tags?.contains("default") == true
+            version.tags?.contains("default") == true
         } ?: error("Cannot find default version in test device catalog: $catalog")
         EnvironmentMatrix(
             androidDeviceList = AndroidDeviceList(
@@ -137,7 +137,10 @@ class FirebaseTestLabController(
     /**
      * Matches given APKs by name as test apk and app apk and starts tests for them
      */
-    suspend fun pairAndStartTests(apks: List<UploadedApk>): List<TestMatrix> {
+    suspend fun pairAndStartTests(
+        apks: List<UploadedApk>,
+        placeholderApk: UploadedApk
+    ): List<TestMatrix> {
         val pairs = apks.mapNotNull { uploadedApk ->
             val isTestApk = uploadedApk.apkInfo.filePath.endsWith(TEST_APK_SUFFIX)
             if (isTestApk) {
@@ -149,7 +152,8 @@ class FirebaseTestLabController(
                 if (appApk != null) {
                     appApk to uploadedApk
                 } else {
-                    null
+                    logger.info("using placeholder app apk for $uploadedApk")
+                    placeholderApk to uploadedApk
                 }
             } else {
                 null

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/ToolsResultStore.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/ToolsResultStore.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.testRunner
+
+import dev.androidx.ci.firebase.ToolsResultApi
+import dev.androidx.ci.generated.testResults.History
+import dev.androidx.ci.util.LazyComputedValue
+import org.apache.logging.log4j.kotlin.logger
+import java.util.UUID
+
+/**
+ * Handles histories for test runs.
+ */
+class ToolsResultStore(
+    private val firebaseProjectId: String,
+    private val toolsResultApi: ToolsResultApi
+) {
+    private val logger = logger()
+    private val cache = mutableMapOf<String, LazyComputedValue<String>>()
+    suspend fun getHistoryId(
+        name: String
+    ): String {
+        logger.info {
+            "finding history id for $name"
+        }
+        return cache.getOrPut(name) {
+            LazyComputedValue {
+                getOrCreateHistory(name).also {
+                    logger.info {
+                        "history id for $name is $it"
+                    }
+                }
+            }
+        }.get()
+    }
+
+    private suspend fun getOrCreateHistory(name: String): String {
+        // there might be many, choose the first one
+        toolsResultApi.getHistories(
+            projectId = firebaseProjectId,
+            name = name
+        ).histories?.firstOrNull()?.let {
+            logger.info {
+                "found history id in existing histories: $it"
+            }
+            return checkNotNull(it.historyId) {
+                "history id cannot be null"
+            }
+        }
+        // create a new one
+        val history = History(
+            name = name,
+            displayName = name,
+            testPlatform = History.TestPlatform.android,
+        )
+        logger.info {
+            "creating new history: $history"
+        }
+        val requestId = UUID.randomUUID().toString()
+        return toolsResultApi.create(
+            projectId = firebaseProjectId,
+            requestId = requestId,
+            history = history
+        ).let {
+            logger.info {
+                "created new history: $history"
+            }
+            checkNotNull(it.historyId) {
+                "history id cannot be null"
+            }
+        }
+    }
+}

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/vo/ApkInfo.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/vo/ApkInfo.kt
@@ -35,6 +35,10 @@ data class ApkInfo(
         filePath.split('/').last()
     }
 
+    val fileNameWithoutExtension: String by lazy {
+        fileName.split('.').dropLast(1).joinToString(".")
+    }
+
     val filePathWithoutExtension: String by lazy {
         filePath.split('.').dropLast(1).joinToString("/")
     }

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeBackend.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeBackend.kt
@@ -26,6 +26,7 @@ class FakeBackend(
     val fakeGithubApi: FakeGithubApi = FakeGithubApi(),
     val fakeGoogleCloudApi: FakeGoogleCloudApi = FakeGoogleCloudApi(),
     val fakeFirebaseTestLabApi: FakeFirebaseTestLabApi = FakeFirebaseTestLabApi(),
+    val fakeToolsResultApi: FakeToolsResultApi = FakeToolsResultApi(),
     val datastoreApi: FakeDatastore = FakeDatastore(),
     val firebaseProjectId: String = "project1",
     randomSeed: Long = -1

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeToolsResultApi.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeToolsResultApi.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.fake
+
+import com.google.common.truth.Truth.assertThat
+import dev.androidx.ci.firebase.ToolsResultApi
+import dev.androidx.ci.generated.testResults.History
+import dev.androidx.ci.generated.testResults.ListHistoriesResponse
+import java.util.UUID
+
+class FakeToolsResultApi : ToolsResultApi {
+    private val histories = mutableListOf<History>()
+    override suspend fun getHistories(projectId: String, name: String?, pageSize: Int): ListHistoriesResponse {
+        return ListHistoriesResponse(
+            nextPageToken = null,
+            histories = histories.filter {
+                name == null || it.name == name
+            }
+        )
+    }
+
+    override suspend fun create(projectId: String, requestId: String?, history: History): History {
+        assertThat(
+            getHistories(
+                projectId = "",
+                name = history.name
+            ).histories
+        ).isEmpty()
+        val created = history.copy(
+            historyId = UUID.randomUUID().toString()
+        )
+        histories.add(
+            created
+        )
+        return created
+    }
+}

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/firebase/ToolsResultApiPlaygroundTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/firebase/ToolsResultApiPlaygroundTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.firebase
+
+import dev.androidx.ci.config.Config
+import dev.androidx.ci.testRunner.ToolsResultStore
+import dev.androidx.ci.util.GoogleCloudCredentialsRule
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+
+class ToolsResultApiPlaygroundTest {
+    private val projectId = "androidx-dev-prod"
+    @get:Rule
+    val playgroundCredentialsRule = GoogleCloudCredentialsRule()
+
+    private val api by lazy {
+        ToolsResultApi.build(
+            config = Config.ToolsResult(
+                credentials = playgroundCredentialsRule.credentials
+            )
+        )
+    }
+
+    @Test
+    fun getHistories() = runBlocking<Unit> {
+        val histories = api.getHistories(projectId = projectId, name = "androidx.room.integration.noappcompat")
+        println(histories)
+    }
+
+    @Test
+    fun getOrCreateHistoryId() = runBlocking<Unit> {
+        val store = ToolsResultStore(
+            firebaseProjectId = projectId,
+            toolsResultApi = api
+        )
+        val historyId = store.getHistoryId("work-work-runtime_work-runtime-debug-androidTest")
+        println(historyId)
+    }
+}

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/ApkStoreTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/ApkStoreTest.kt
@@ -63,4 +63,11 @@ class ApkStoreTest {
         assertThat(gcpApi.artifacts()).hasSize(3)
         assertThat(newName.gcsPath).isNotEqualTo(uploaded.gcsPath)
     }
+
+    @Test
+    fun placeholderApk() = runBlocking<Unit> {
+        val placeholderApk = apkStore.getPlaceholderApk()
+        assertThat(gcpApi.uploadCount).isEqualTo(1)
+        assertThat(gcpApi.artifacts()[placeholderApk.gcsPath]).isNotNull()
+    }
 }

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/FirebaseTestLabControllerTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/FirebaseTestLabControllerTest.kt
@@ -33,6 +33,7 @@ class FirebaseTestLabControllerTest {
             firebaseProjectId = fakeBackend.firebaseProjectId,
             datastoreApi = fakeBackend.datastoreApi,
             firebaseTestLabApi = fakeBackend.fakeFirebaseTestLabApi,
+            toolsResultApi = fakeBackend.fakeToolsResultApi,
             resultsGcsPrefix = GcsPath("gs://test-results")
         )
     )
@@ -43,20 +44,22 @@ class FirebaseTestLabControllerTest {
         val app1TestApk = createUploadedApk("app1-androidTest.apk")
         val app2Apk = createUploadedApk("app2.apk")
         val app2TestApk = createUploadedApk("app2-androidTest.apk")
+        val placeholderApk = createUploadedApk("placeholder.apk")
+        val noAppTestApk = createUploadedApk("no-app-apk-androidTest.apk")
         val apks = listOf(
             app1TestApk,
             createUploadedApk("foo.apk"),
             createUploadedApk("bar.apk"),
             app1Apk,
             app2Apk,
-            createUploadedApk("no-app-apk-androidTest.apk"),
+            noAppTestApk,
             app2TestApk,
         )
         val testMatrices = firebaseTestLabApi.pairAndStartTests(
-            apks
+            apks = apks,
+            placeholderApk = placeholderApk
         )
-        // only test for app ones.
-        assertThat(testMatrices).hasSize(2)
+        assertThat(testMatrices).hasSize(3)
         val appApkPaths = testMatrices.mapNotNull {
             it.testSpecification.androidInstrumentationTest?.let {
                 it.appApk!!.gcsPath to it.testApk.gcsPath
@@ -67,7 +70,8 @@ class FirebaseTestLabControllerTest {
         ).containsExactlyElementsIn(
             listOf(
                 app1Apk.gcsPath.path to app1TestApk.gcsPath.path,
-                app2Apk.gcsPath.path to app2TestApk.gcsPath.path
+                app2Apk.gcsPath.path to app2TestApk.gcsPath.path,
+                placeholderApk.gcsPath.path to noAppTestApk.gcsPath.path
             )
         )
     }

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestMatrixStoreTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestMatrixStoreTest.kt
@@ -19,6 +19,7 @@ package dev.androidx.ci.testRunner
 import com.google.common.truth.Truth.assertThat
 import dev.androidx.ci.fake.FakeDatastore
 import dev.androidx.ci.fake.FakeFirebaseTestLabApi
+import dev.androidx.ci.fake.FakeToolsResultApi
 import dev.androidx.ci.gcloud.GcsPath
 import dev.androidx.ci.generated.ftl.AndroidDevice
 import dev.androidx.ci.generated.ftl.AndroidDeviceList
@@ -32,10 +33,12 @@ import org.junit.Test
 class TestMatrixStoreTest {
     val firebaseTestLabApi = FakeFirebaseTestLabApi()
     val datastoreApi = FakeDatastore()
+    val toolsResultApi = FakeToolsResultApi()
     private val store = TestMatrixStore(
         firebaseProjectId = "p1",
         firebaseTestLabApi = firebaseTestLabApi,
         datastoreApi = datastoreApi,
+        toolsResultApi = toolsResultApi,
         resultsGcsPrefix = GcsPath("gs://test")
     )
 

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerPlayground.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerPlayground.kt
@@ -19,6 +19,7 @@ package dev.androidx.ci.testRunner
 import dev.androidx.ci.config.Config
 import dev.androidx.ci.datastore.DatastoreApi
 import dev.androidx.ci.firebase.FirebaseTestLabApi
+import dev.androidx.ci.firebase.ToolsResultApi
 import dev.androidx.ci.gcloud.GoogleCloudApi
 import dev.androidx.ci.github.GithubApi
 import dev.androidx.ci.util.GithubAuthRule
@@ -49,7 +50,7 @@ class TestRunnerPlayground {
 
     @Before
     fun initRunner() {
-        val runId = "821097113"
+        val runId = "909092033"
         testRunner = TestRunner(
             googleCloudApi = GoogleCloudApi.build(
                 Config.GCloud(
@@ -68,6 +69,11 @@ class TestRunnerPlayground {
             ),
             firebaseTestLabApi = FirebaseTestLabApi.build(
                 config = Config.FirebaseTestLab(
+                    credentials = playgroundCredentialsRule.credentials
+                )
+            ),
+            toolsResultApi = ToolsResultApi.build(
+                config = Config.ToolsResult(
                     credentials = playgroundCredentialsRule.credentials
                 )
             ),

--- a/AndroidXCI/placeholderapp/build.gradle.kts
+++ b/AndroidXCI/placeholderapp/build.gradle.kts
@@ -14,26 +14,21 @@
  * limitations under the License.
  */
 
-package dev.androidx.ci.codegen.plugin
-
-import org.gradle.api.provider.ListProperty
-import java.io.Serializable
-
-/**
- * Extension to configure the settings for model generation.
- */
-interface GeneratedModelsExtension {
-    val models: ListProperty<GeneratedModelInfo>
+plugins {
+    id("com.android.application") version("7.0.0-beta03")
 }
 
-data class GeneratedModelInfo(
-    /**
-     * The URL to the discovery file
-     */
-    val discoveryFileUrl: String,
+android {
+    compileSdk = 30
+    buildToolsVersion = "30.0.3"
 
-    /**
-     * Root package for generated classes
-     */
-    val pkg: String
-) : Serializable
+    defaultConfig {
+        applicationId = "dev.androidx.ci.emptyapp"
+        minSdk = 14
+        targetSdk = 30
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+}

--- a/AndroidXCI/placeholderapp/src/main/AndroidManifest.xml
+++ b/AndroidXCI/placeholderapp/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2021 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="dev.androidx.ci.placeholderapp">
+
+    <application android:label="placeholder app" />
+
+</manifest>

--- a/AndroidXCI/settings.gradle.kts
+++ b/AndroidXCI/settings.gradle.kts
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 enableFeaturePreview("VERSION_CATALOGS")
 include(":lib")
 include(":cli")
+include(":placeholderapp")
 pluginManagement {
     includeBuild("ftlModelBuilder")
     repositories {
         gradlePluginPortal()
         mavenCentral()
+        google()
     }
 }


### PR DESCRIPTION
FTL always requires a test apk, hence we cannot run instrumentation
tests for libraries.

This CL adds an android module which gets compiled into resources to
be used as a placeholder apk when we don't have one.

Unfortunately, FTL also uses that APKs package to decide on the History
name. To avoid having all library tests under 1 name, I've implemented
integration with the tools reseult API to create a history. Luckily, I
over engineered when we needed the FTL API so i was able to re-use that to
generate models for the ToolsResult API. For now, we use the test apk name
as the history name which we may want to change later. This also means we'll
duplicate all histories (they use package name). There is no API to delete them
but I'm hoping that aafter 90 days, they'll disappear.