### PR TITLE
Download test artifacts into out folder

### DIFF
--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/vo/TestResult.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/vo/TestResult.kt
@@ -27,7 +27,7 @@ sealed class TestResult(
 ) {
     abstract val allTestsPassed: Boolean
 
-    class CompleteRun(
+    data class CompleteRun(
         val matrices: List<TestMatrix>
     ) : TestResult(Type.COMPLETE_RUN) {
         override val allTestsPassed: Boolean by lazy {
@@ -37,7 +37,7 @@ sealed class TestResult(
         }
     }
 
-    class IncompleteRun(
+    data class IncompleteRun(
         val stacktrace: String
     ) : TestResult(Type.INCOMPLETE_RUN) {
         override val allTestsPassed: Boolean
@@ -69,5 +69,7 @@ sealed class TestResult(
             .addLast(MetadataKotlinJsonAdapterFactory())
             .build()
         private val adapter = moshi.adapter(TestResult::class.java).indent("  ").lenient()
+
+        fun fromJson(json: String) = adapter.fromJson(json)
     }
 }

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeGoogleCloudApi.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeGoogleCloudApi.kt
@@ -18,6 +18,7 @@ package dev.androidx.ci.fake
 
 import dev.androidx.ci.gcloud.GcsPath
 import dev.androidx.ci.gcloud.GoogleCloudApi
+import java.io.File
 
 /**
  * A simple implementation of [GoogleCloudApi] for testing and verification.
@@ -42,6 +43,12 @@ class FakeGoogleCloudApi : GoogleCloudApi {
         val path = makeGcsPath(relativePath)
         artifacts[path] = bytes
         return path
+    }
+
+    override suspend fun download(gcsPath: GcsPath, target: File, filter: (String) -> Boolean) {
+        target.resolve("downloadedFile.txt").writeText(
+            gcsPath.path, Charsets.UTF_8
+        )
     }
 
     override suspend fun existingFilePath(relativePath: String): GcsPath? {

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/gcloud/GoogleCloudApiPlaygroundTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/gcloud/GoogleCloudApiPlaygroundTest.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
@@ -39,6 +40,9 @@ import org.junit.runners.JUnit4
 class GoogleCloudApiPlaygroundTest {
     @get:Rule
     val playgroundCredentialsRule = GoogleCloudCredentialsRule()
+
+    @get:Rule
+    val tmpFolder = TemporaryFolder()
 
     private val testScope = TestCoroutineScope()
     @Test
@@ -60,5 +64,28 @@ class GoogleCloudApiPlaygroundTest {
         ).isEqualTo(
             GcsPath("gs://androidx-ftl-test-results/testing/unitTest.txt")
         )
+    }
+
+    @Test
+    fun downloadFolder() = testScope.runBlockingTest {
+        val folder = tmpFolder.newFolder()
+        val client = GoogleCloudApi.build(
+            config = Config.GCloud(
+                credentials = playgroundCredentialsRule.credentials,
+                bucketName = "androidx-ftl-test-results",
+                bucketPath = "github-ci-action"
+            ),
+            context = testScope.coroutineContext
+        )
+        val path = GcsPath(
+            "gs://androidx-ftl-test-results/github-ci-action/ftl/821097113"
+        )
+        client.download(
+            path,
+            folder
+        ) {
+            !it.contains("test_cases")
+        }
+        println("donwloaded")
     }
 }


### PR DESCRIPTION
This PR adds the last missing piece of pulling results from GCP into the output folder
so that test results are visible via github.

One day, maybe one day if we migrate to this, we can have a UI in
androidx.dev instead...