### PR TITLE
Build distribution for pushed tags

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -58,7 +58,9 @@ jobs:
           git add .github
 
           # replace src build command with dist
-          sed '/\#SRC/!b;n;d' action.yml| sed 's/\#DIST//'| sed '/SRC/d' > action.yml
+          REPLACE_TOKEN="#REPLACE_NEXT_LINE"
+          sed -i "/$REPLACE_TOKEN/{n;d}" action.yml
+          sed -i "s/$REPLACE_TOKEN//g" action.yml
           git add action.yml
 
           # copy install into dist folder

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,0 +1,69 @@
+# when `latest` tag or another tag starting with `v` is pushed,
+# this workflow runs to push the distrubtion into a `dist-<tag>`
+# tag
+name: DISTRIBUTE
+
+on:
+  push:
+    tags:
+      - latest
+      - v*
+
+jobs:
+  distribute:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: "checkout"
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      # always test before dist
+      - uses: eskatos/gradle-command-action@v1
+        with: 
+          build-root-directory: AndroidXCI
+          wrapper-directory: AndroidXCI
+          wrapper-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true
+          arguments: check :ftlModelBuilder:check
+      # build distribution
+      - uses: eskatos/gradle-command-action@v1
+        with: 
+          build-root-directory: AndroidXCI
+          wrapper-directory: AndroidXCI
+          wrapper-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: true
+          arguments: installDist
+      # push it to a new git tag
+      - name: "create dist branch"
+        id: event-args
+        run: |
+          set -x
+          REF="${{ github.event.ref }}"
+          TAG=$(echo $REF| sed 's/refs\/tags\///')
+          DIST_TAG="dist-$TAG"
+          git config user.email "${{ github.event.head_commit.author.email }}"
+          git config user.name "${{ github.event.head_commit.author.name }}"
+          git checkout -b tmp-$DIST_TAG
+          # remove workflow etc, otherwise we'll need workflow override permissions
+          rm -rf .github
+          git add .github
+
+          # replace src build command with dist
+          sed '/\#SRC/!b;n;d' action.yml| sed 's/\#DIST//'| sed '/SRC/d' > action.yml
+          git add action.yml
+
+          # copy install into dist folder
+          cp -R AndroidXCI/cli/build/install/cli dist
+          # add the dist folder
+          git add dist
+          git commit -m "distrubtion for $TAG in $DIST_TAG branch"
+          git tag -a $DIST_TAG -m "dist for $TAG" -f
+          git push origin $DIST_TAG -f
+          echo "done pushing to git"

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -24,6 +24,7 @@ jobs:
           distribution: 'adopt'
       # always test before dist
       - uses: eskatos/gradle-command-action@v1
+        name: Build and Test
         with: 
           build-root-directory: AndroidXCI
           wrapper-directory: AndroidXCI
@@ -33,13 +34,14 @@ jobs:
           arguments: check :ftlModelBuilder:check
       # build distribution
       - uses: eskatos/gradle-command-action@v1
+        name: Build Distribution
         with: 
           build-root-directory: AndroidXCI
           wrapper-directory: AndroidXCI
           wrapper-cache-enabled: true
           dependencies-cache-enabled: true
           configuration-cache-enabled: true
-          arguments: installDist
+          arguments: :cli:installDist
       # push it to a new git tag
       - name: "create dist branch"
         id: event-args

--- a/AndroidXCI/cli/build.gradle.kts
+++ b/AndroidXCI/cli/build.gradle.kts
@@ -15,7 +15,6 @@
  */
 
 plugins {
-    `kotlin-dsl`
     kotlin("jvm")
     id("org.jlleitschuh.gradle.ktlint")
     `application`

--- a/AndroidXCI/ftlModelBuilder/build.gradle.kts
+++ b/AndroidXCI/ftlModelBuilder/build.gradle.kts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-    kotlin("jvm") version "1.4.31"
     `java-gradle-plugin`
+    `kotlin-dsl`
     id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
 }
 repositories {

--- a/AndroidXCI/lib/build.gradle.kts
+++ b/AndroidXCI/lib/build.gradle.kts
@@ -17,7 +17,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
  */
 
 plugins {
-    `kotlin-dsl`
     kotlin("jvm")
     id("org.jlleitschuh.gradle.ktlint")
     id("androidx-model-builder")

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ This repository contains custom post-workflow actions for AndroidX.
 Even though it is public, it is not intended to be used in repositories
 other than [AndroidX/androidx](https://github.com/androidX/androidx).
 
+## Releasing
+Each time a tag is pushed for `latest` or `v*`; a distrubtion build is
+prepared in CI that will be pushed at `dist-<tagname>` tag.
+See `dist.yml` build action for details.
+
 Copyright:
 
     Copyright 2020 Google LLC

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # dist.yml script swaps the SRC with DIST when building distribution
+    #SRC
     - run: cd ${{ github.action_path }}/AndroidXCI && ./gradlew :cli:run
+    #DIST- run: ${{ github.action_path }}/dist/bin/cli
       shell: bash
       env:
         ANDROIDX_GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/action.yml
+++ b/action.yml
@@ -16,10 +16,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # dist.yml script swaps the SRC with DIST when building distribution
-    #SRC
+    # dist.yml will parse the marker below and replace the next line
+    #REPLACE_NEXT_LINE- run: ${{ github.action_path }}/dist/bin/cli
     - run: cd ${{ github.action_path }}/AndroidXCI && ./gradlew :cli:run
-    #DIST- run: ${{ github.action_path }}/dist/bin/cli
       shell: bash
       env:
         ANDROIDX_GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
This PR adds a new workflow that will build a distribution version of the workflow whenever a new `tag` is pushed if the tag name is either `latest` or `v*`. Distribution tags are prefixed by `dist` so if you push tag `v1.0`, this workflow will create `dist-v1.0`.

This saves us the ~2m we spend on rebuilding this library on each run.

Test: https://github.com/androidx/androidx/runs/2900479383?check_suite_focus=true