### PR TITLE
Use test package name for history id on firebase

### DIFF
--- a/AndroidXCI/build.gradle.kts
+++ b/AndroidXCI/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     // cannot use version catalog here yet:
     // https://melix.github.io/blog/2021/03/version-catalogs-faq.html#_can_i_use_a_version_catalog_to_declare_plugin_versions
-    kotlin("jvm") version "1.4.31" apply false
+    kotlin("jvm") version "1.5.30" apply false
     id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
     id("org.jlleitschuh.gradle.ktlint-idea") version "10.0.0"
 }

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/firebase/FirebaseTestLabApi.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/firebase/FirebaseTestLabApi.kt
@@ -19,6 +19,8 @@ package dev.androidx.ci.firebase
 import com.squareup.moshi.Moshi
 import dev.androidx.ci.config.Config
 import dev.androidx.ci.firebase.dto.EnvironmentType
+import dev.androidx.ci.generated.ftl.FileReference
+import dev.androidx.ci.generated.ftl.GetApkDetailsResponse
 import dev.androidx.ci.generated.ftl.TestEnvironmentCatalog
 import dev.androidx.ci.generated.ftl.TestMatrix
 import dev.androidx.ci.util.Retry
@@ -54,6 +56,12 @@ interface FirebaseTestLabApi {
         @Path("environmentType") environmentType: EnvironmentType,
         @Query("projectId") projectId: String,
     ): TestEnvironmentCatalog
+
+    @Retry
+    @POST("applicationDetailService/getApkDetails")
+    suspend fun getApkDetails(
+        @Body fileReference: FileReference
+    ): GetApkDetailsResponse
 
     companion object {
         fun build(

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeFirebaseTestLabApi.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeFirebaseTestLabApi.kt
@@ -19,6 +19,10 @@ package dev.androidx.ci.fake
 import com.squareup.moshi.Moshi
 import dev.androidx.ci.firebase.FirebaseTestLabApi
 import dev.androidx.ci.firebase.dto.EnvironmentType
+import dev.androidx.ci.generated.ftl.ApkDetail
+import dev.androidx.ci.generated.ftl.ApkManifest
+import dev.androidx.ci.generated.ftl.FileReference
+import dev.androidx.ci.generated.ftl.GetApkDetailsResponse
 import dev.androidx.ci.generated.ftl.TestEnvironmentCatalog
 import dev.androidx.ci.generated.ftl.TestMatrix
 import dev.zacsweers.moshix.reflect.MetadataKotlinJsonAdapterFactory
@@ -34,6 +38,7 @@ class FakeFirebaseTestLabApi(
 ) : FirebaseTestLabApi {
     private val testMatrices = mutableMapOf<String, TestMatrix>()
     private var environmentCatalog: TestEnvironmentCatalog? = null
+    private val apkToPkgMap = mutableMapOf<String, String>()
 
     /**
      * Read the catalog from a recorded request
@@ -94,5 +99,22 @@ class FakeFirebaseTestLabApi(
         projectId: String
     ): TestEnvironmentCatalog {
         return environmentCatalog ?: realEnvironmentCatalog
+    }
+
+    override suspend fun getApkDetails(fileReference: FileReference): GetApkDetailsResponse {
+        val packageName = apkToPkgMap.getOrPut(fileReference.gcsPath!!) {
+            "$FAKE_PKG_PREFIX${apkToPkgMap.size}"
+        }
+        return GetApkDetailsResponse(
+            apkDetail = ApkDetail(
+                apkManifest = ApkManifest(
+                    packageName = packageName
+                )
+            )
+        )
+    }
+
+    companion object {
+        const val FAKE_PKG_PREFIX = "androidx.fake.pkg"
     }
 }

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/firebase/FakeFirebaseTestLabApiTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/firebase/FakeFirebaseTestLabApiTest.kt
@@ -20,6 +20,7 @@ import com.google.common.truth.Truth.assertThat
 import dev.androidx.ci.fake.FakeFirebaseTestLabApi
 import dev.androidx.ci.firebase.dto.EnvironmentType
 import dev.androidx.ci.generated.ftl.EnvironmentMatrix
+import dev.androidx.ci.generated.ftl.FileReference
 import dev.androidx.ci.generated.ftl.GoogleCloudStorage
 import dev.androidx.ci.generated.ftl.ResultStorage
 import dev.androidx.ci.generated.ftl.TestEnvironmentCatalog
@@ -107,5 +108,29 @@ class FakeFirebaseTestLabApiTest {
             )
 
         ).isEqualTo(catalog)
+    }
+
+    @Test
+    fun getApkDetails() = runBlockingTest {
+        val fileRef1 = FileReference(
+            gcsPath = "gs://foo/bar.apk"
+        )
+        val fileRef2 = FileReference(
+            gcsPath = "gs://foo/baz.apk"
+        )
+        val pkg1 = fakeApi.getApkDetails(
+            fileRef1
+        ).apkDetail?.apkManifest?.packageName
+        assertThat(pkg1).isEqualTo("androidx.fake.pkg0")
+        val pkg2 = fakeApi.getApkDetails(
+            fileRef2
+        ).apkDetail?.apkManifest?.packageName
+        assertThat(pkg2).isEqualTo("androidx.fake.pkg1")
+        val pkg1Dupe = fakeApi.getApkDetails(
+            FileReference(
+                gcsPath = fileRef1.gcsPath
+            )
+        ).apkDetail?.apkManifest?.packageName
+        assertThat(pkg1Dupe).isEqualTo(pkg1)
     }
 }

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/firebase/FirebaseTestLabApiPlaygroundTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/firebase/FirebaseTestLabApiPlaygroundTest.kt
@@ -68,4 +68,21 @@ class FirebaseTestLabApiPlaygroundTest {
         )
         println(catalog)
     }
+
+    @Test
+    fun getApkDetails() = runBlocking {
+        val ftl = FirebaseTestLabApi.build(
+            config = Config.FirebaseTestLab(
+                credentials = playgroundCredentialsRule.credentials
+            )
+        )
+        val testMatrix = ftl.getTestMatrix(
+            projectId = projectId,
+            testMatrixId = "matrix-3q374rmyj84i1"
+        )
+        val apkDetails = ftl.getApkDetails(
+            testMatrix.testSpecification.androidInstrumentationTest!!.testApk!!
+        )
+        println(apkDetails)
+    }
 }

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/firebase/ToolsResultApiPlaygroundTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/firebase/ToolsResultApiPlaygroundTest.kt
@@ -48,7 +48,7 @@ class ToolsResultApiPlaygroundTest {
             firebaseProjectId = projectId,
             toolsResultApi = api
         )
-        val historyId = store.getHistoryId("work-work-runtime_work-runtime-debug-androidTest")
+        val historyId = store.getHistoryId("androidx.compose.testutils.test")
         println(historyId)
     }
 }

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/FirebaseTestLabControllerTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/FirebaseTestLabControllerTest.kt
@@ -77,7 +77,7 @@ class FirebaseTestLabControllerTest {
     }
 
     private fun createUploadedApk(
-        name: String
+        name: String,
     ) = UploadedApk(
         gcsPath = GcsPath("gs://apk/$name"),
         apkInfo = ApkInfo(

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerPlayground.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerPlayground.kt
@@ -50,7 +50,7 @@ class TestRunnerPlayground {
 
     @Before
     fun initRunner() {
-        val runId = "909092033"
+        val runId = "1243675283"
         testRunner = TestRunner(
             googleCloudApi = GoogleCloudApi.build(
                 Config.GCloud(
@@ -85,7 +85,7 @@ class TestRunnerPlayground {
                 context = Dispatchers.IO
             ),
             githubArtifactFilter = {
-                it.name.contains("artifacts_room")
+                it.name.contains("artifacts_navigation")
             },
             targetRunId = runId,
             hostRunId = runId


### PR DESCRIPTION
Previously, we were using test apk names for history name in
FTL. That name can change (based on androidX) and it might also
be too long (100 chars). Instead, this CL replaces it with the
package name of the test apk (using an FTL service). This does
mess up the FTL UI for 3 months but afterwards, should be much
easier to read and much more stable.

Also updated kotlin to 1.5.30