### PR TITLE
Update log4j versions

### DIFF
--- a/AndroidXCI/gradle/libs.versions.toml
+++ b/AndroidXCI/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ truth = { module = "com.google.truth:truth", version.ref = "truth" }
 gcloud-storage = { module = "com.google.cloud:google-cloud-storage", version = "1.113.16"}
 gcloud-datastore = { module = "com.google.cloud:google-cloud-datastore", version = "1.106.4"}
 log4j-kotlin = { module = "org.apache.logging.log4j:log4j-api-kotlin", version = "1.0.0" }
-log4j-core = { module = "org.apache.logging.log4j:log4j-core", version = "2.14.1"}
+log4j-core = { module = "org.apache.logging.log4j:log4j-core", version = "2.16.0"}
 clikt = { module = "com.github.ajalt.clikt:clikt", version = "3.2.0"}
 
 [bundles]

--- a/AndroidXCI/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidXCI/gradle/wrapper/gradle-wrapper.properties
@@ -16,6 +16,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Also updated gradle version to safeguard build phase.

See: https://blog.gradle.org/log4j-vulnerability