### PR TITLE
Append log about failures

### DIFF
--- a/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
+++ b/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
@@ -108,6 +108,9 @@ private class Cli : CliktCommand() {
         if (result.allTestsPassed) {
             exitProcess(0)
         } else {
+            println("================= FAILURE LOG =================")
+            println(result.failureLog)
+            println("===============================================")
             exitProcess(1)
         }
     }

--- a/AndroidXCI/placeholderapp/build.gradle.kts
+++ b/AndroidXCI/placeholderapp/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id("com.android.application") version("7.0.0-beta03")
+    id("com.android.application") version("7.0.0")
 }
 
 android {


### PR DESCRIPTION
Right now, when FTL fails, you have to go through a json file to find
what has failed, which is annoying. This CL adds an additional log to
the end about the failures so that it is easy to find their FTL URL for
further investigation.