### PR TITLE
add publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,4 +26,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: repo
-          path: ${{ GITHUB_WORKSPACE }}/AndroidXCI/build/repo
+          path: ${{ env.GITHUB_WORKSPACE }}/AndroidXCI/build/repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           gradle-home-cache-excludes: |
             caches/jars-9
             caches/transforms-3
-          arguments: check :ftlModelBuilder:check
+          arguments: check :ftlModelBuilder:check publish
           build-root-directory: AndroidXCI
       - name: "Upload build repository"
         continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,3 +21,9 @@ jobs:
           dependencies-cache-enabled: true
           configuration-cache-enabled: true
           arguments: check :ftlModelBuilder:check
+      - name: "Upload build repository"
+        continue-on-error: true
+        uses: actions/upload-artifact@v2
+        with:
+          name: repo
+          path: ${{ GITHUB_WORKSPACE }}/AndroidXCI/build/repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: repo
-          path: ${{ env.GITHUB_WORKSPACE }}/AndroidXCI/build/repo
+          path: AndroidXCI/build/repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,11 @@ name: Test
 
 on: [push, pull_request]
 
+env:
+  # Allow precise monitoring of the save/restore of Gradle User Home by `gradle-build-action`
+  # See https://github.com/marketplace/actions/gradle-build-action?version=v2.1.1#cache-debugging-and-analysis
+  GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,14 +18,19 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      - uses: eskatos/gradle-command-action@v1
-        with: 
-          build-root-directory: AndroidXCI
-          wrapper-directory: AndroidXCI
-          wrapper-cache-enabled: true
-          dependencies-cache-enabled: true
-          configuration-cache-enabled: true
+      - name: "Build and Test"
+        uses: gradle/gradle-build-action@v2
+        with:
+          # Don't reuse cache entries from any other Job.
+          gradle-home-cache-strict-match: true
+
+          # Limit the size of the cache entry.
+          # These directories contain instrumented/transformed dependency jars which can be reconstructed relatively quickly.
+          gradle-home-cache-excludes: |
+            caches/jars-9
+            caches/transforms-3
           arguments: check :ftlModelBuilder:check
+          build-root-directory: AndroidXCI
       - name: "Upload build repository"
         continue-on-error: true
         uses: actions/upload-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ AndroidXCI/.idea
 **/.gradle/**
 !**/.idea/codeStyleSettings.xml
 !**/.idea/copyright
+**/local.properties

--- a/AndroidXCI/build.gradle.kts
+++ b/AndroidXCI/build.gradle.kts
@@ -22,9 +22,6 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint-idea") version "10.0.0"
 }
 
-group = "dev.androidx.build.ci"
-version = "1.0-SNAPSHOT"
-
 repositories {
     mavenCentral()
     google()
@@ -35,6 +32,8 @@ subprojects {
         mavenCentral()
         google()
     }
+    group = "dev.androidx.build.ci"
+    version = "1.0-SNAPSHOT"
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java).configureEach {
         kotlinOptions {
             jvmTarget = "1.8"

--- a/AndroidXCI/gradle.properties
+++ b/AndroidXCI/gradle.properties
@@ -15,3 +15,7 @@
 #
 
 kotlin.code.style=official
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=512m -Dkotlin.daemon.jvm.options=-XX:MaxMetaspaceSize=1g
+org.gradle.configureondemand=true
+org.gradle.parallel=true
+org.gradle.caching=true

--- a/AndroidXCI/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidXCI/gradle/wrapper/gradle-wrapper.properties
@@ -16,6 +16,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/AndroidXCI/lib/build.gradle.kts
+++ b/AndroidXCI/lib/build.gradle.kts
@@ -84,11 +84,3 @@ java {
 compileKotlin.kotlinOptions {
     freeCompilerArgs = listOf("-Xinline-classes")
 }
-
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            from(components["java"])
-        }
-    }
-}

--- a/AndroidXCI/lib/build.gradle.kts
+++ b/AndroidXCI/lib/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
     kotlin("jvm")
     id("org.jlleitschuh.gradle.ktlint")
     id("androidx-model-builder")
+    id("maven-publish")
 }
 
 generatedModels {
@@ -82,4 +83,12 @@ java {
 }
 compileKotlin.kotlinOptions {
     freeCompilerArgs = listOf("-Xinline-classes")
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+        }
+    }
 }


### PR DESCRIPTION
This PR adds publishing support to lib, which would make it relatively easier to pull into AndroidX.
We'll likely end up writing a gradle plugin in here as well but in either case, this will be necessary

Also cleaned up the build scripts a bit and updated gradle to 7.4.2