### PR TITLE
Expand CLI ci-action

### DIFF
--- a/AndroidXCI/cli/build.gradle.kts
+++ b/AndroidXCI/cli/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(libs.coroutines.core)
     implementation(libs.clikt)
     implementation(libs.bundles.log4j)
+    testImplementation(libs.truth)
 }
 
 application {

--- a/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
+++ b/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
@@ -254,9 +254,9 @@ data class DeviceSpec(
             val parts = spec.split(":")
             require(parts.size == 2) {
                 """
-                        Each device spec should have two parts separated by ':'.
-                        Invalid input: $spec
-                    """
+                Each device spec should have two parts separated by ':'.
+                Invalid input: $spec
+                """
             }
             val deviceId = parts[0].trim().also {
                 require(it.isNotBlank()) {

--- a/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
+++ b/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
@@ -20,6 +20,9 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
+import dev.androidx.ci.generated.ftl.AndroidDevice
+import dev.androidx.ci.generated.ftl.TestEnvironmentCatalog
+import dev.androidx.ci.testRunner.DevicePicker
 import dev.androidx.ci.testRunner.TestRunner
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -28,6 +31,7 @@ import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.core.appender.FileAppender
 import org.apache.logging.log4j.core.layout.PatternLayout
+import java.io.File
 import java.util.concurrent.TimeUnit
 import kotlin.system.exitProcess
 
@@ -74,6 +78,14 @@ private class Cli : CliktCommand() {
         envvar = "ANDROIDX_OUTPUT_FOLDER"
     ).file(canBeFile = false, canBeDir = true).required()
 
+    val logFile by option(
+        help = """
+            The output file for test runner logs. Make sure this is different from the output
+            folder so that it will not be deleted when outputs are being downloaded
+        """.trimIndent(),
+        envvar = "ANDROIDX_LOG_FILE"
+    ).file(canBeFile = true, canBeDir = false)
+
     val githubRepository by option(
         help = """
             The github repository which is running this action.
@@ -82,14 +94,49 @@ private class Cli : CliktCommand() {
         envvar = "GITHUB_REPOSITORY"
     ).required()
 
+    val deviceSpecs by option(
+        help = """
+            List of device - sdk pairs to run the tests.
+            Each spec should be in the form of <id>:<sdkVersion> concatenated by ','.
+            e.g. "redfin:30, sailfish:25"
+        """.trimIndent(),
+        envvar = "ANDROIDX_DEVICE_SPECS",
+    )
+
+    val artifactNameRegex by option(
+        help = """
+            Regex to filter artifacts. If empty, all artifacts will be checked for apks which
+            might be too big.
+            e.g. "tests*zip"
+        """.trimIndent(),
+        envvar = "ANDROIDX_ARTIFACT_NAME_FILTER_REGEX"
+    )
+
+    val gcpBucketName by option(
+        help = """
+            Bucket name to use for artifacts
+        """.trimIndent(),
+        envvar = "ANDROIDX_BUCKET_NAME"
+    ).required()
+
+    val gcpBucketPath by option(
+        help = """
+            Bucket path to use for artifacts
+        """.trimIndent(),
+        envvar = "ANDROIDX_BUCKET_PATH"
+    ).required()
+
     override fun run() {
-        configureLogger()
+        logFile?.let(::configureLogger)
         val repoParts = githubRepository.split("/")
         check(repoParts.size >= 2) {
             "invalid github repo: $githubRepository"
         }
         val githubOwner = repoParts.first()
         val githubRepo = repoParts.drop(1).joinToString("/")
+        val artifactNameFilter = artifactNameRegex?.let { input ->
+            createRegexArtifactFilter(input)
+        } ?: acceptAll
         val result = runBlocking {
             val testRunner = TestRunner.create(
                 targetRunId = targetRunId,
@@ -99,7 +146,11 @@ private class Cli : CliktCommand() {
                 ioDispatcher = Dispatchers.IO,
                 outputFolder = outputFolder,
                 githubOwner = githubOwner,
-                githubRepo = githubRepo
+                githubRepo = githubRepo,
+                devicePicker = deviceSpecs?.let(::createDevicePicker),
+                artifactNameFilter = artifactNameFilter,
+                bucketName = gcpBucketName,
+                bucketPath = gcpBucketPath
             )
             testRunner.runTests()
         }
@@ -115,15 +166,30 @@ private class Cli : CliktCommand() {
         }
     }
 
+    private val acceptAll = { _: String ->
+        true
+    }
+
+    private fun createRegexArtifactFilter(
+        input: String
+    ): (String) -> Boolean {
+        val regex = input.toRegex()
+        return { artifactName ->
+            regex.matches(artifactName)
+        }
+    }
     /**
      * Add new logger to log into the output directory.
      */
-    private fun configureLogger() {
+    private fun configureLogger(
+        logFile: File
+    ) {
+        logFile.parentFile.mkdirs()
         val ctx = LogManager.getContext(false) as LoggerContext
         val config = ctx.configuration
         val layout = PatternLayout.createDefaultLayout(config)
         val appender = FileAppender.newBuilder<FileAppender.Builder<*>>()
-            .withFileName(outputFolder.resolve("logs.txt").absolutePath)
+            .withFileName(logFile.absolutePath)
             .withAppend(false)
             .withImmediateFlush(false)
             .setName("File")
@@ -145,6 +211,73 @@ private class Cli : CliktCommand() {
     private fun flushLogs() {
         val ctx = LogManager.getContext(false) as LoggerContext
         ctx.stop(10, TimeUnit.SECONDS)
+    }
+
+    fun createDevicePicker(
+        rawInput: String
+    ): DevicePicker {
+        val specs = DeviceSpec.parseSpecs(rawInput)
+        check(specs.isNotEmpty()) {
+            "Empty device specs: $rawInput"
+        }
+        return { catalog: TestEnvironmentCatalog ->
+            val models = checkNotNull(catalog.androidDeviceCatalog?.models) {
+                "No models in the environment catalog: $catalog"
+            }
+            specs.map { spec ->
+                // validate we have a matching model.
+                val model = models.find {
+                    it.id == spec.deviceId && it.supportedVersionIds?.contains(spec.sdk) == true
+                }
+                checkNotNull(model) {
+                    "Cannot find $spec in models: $models"
+                }
+                AndroidDevice(
+                    orientation = "portrait",
+                    androidModelId = model.id,
+                    locale = "en",
+                    androidVersionId = spec.sdk
+                )
+            }
+        }
+    }
+}
+
+data class DeviceSpec(
+    val deviceId: String,
+    val sdk: String
+) {
+    companion object {
+        private fun parseSpec(spec: String): DeviceSpec {
+            @Suppress("NAME_SHADOWING")
+            val spec = spec.trim()
+            val parts = spec.split(":")
+            require(parts.size == 2) {
+                """
+                        Each device spec should have two parts separated by ':'.
+                        Invalid input: $spec
+                    """
+            }
+            val deviceId = parts[0].trim().also {
+                require(it.isNotBlank()) {
+                    "Device id cannot be blank"
+                }
+            }
+            val sdkVersion = parts[1].trim().also {
+                require(it.isNotBlank()) {
+                    "SDK cannot be blank"
+                }
+            }
+            return DeviceSpec(
+                deviceId = deviceId,
+                sdk = sdkVersion
+            )
+        }
+        fun parseSpecs(input: String): List<DeviceSpec> {
+            return input.split(",").map {
+                it.trim()
+            }.map(::parseSpec)
+        }
     }
 }
 

--- a/AndroidXCI/cli/src/test/kotlin/dev/androidx/ci/cli/DeviceSpecTest.kt
+++ b/AndroidXCI/cli/src/test/kotlin/dev/androidx/ci/cli/DeviceSpecTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.cli
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class DeviceSpecTest {
+    @Test
+    fun parseSingle() {
+        assertThat(
+            DeviceSpec.parseSpecs("foo:23")
+        ).containsExactly(
+            DeviceSpec("foo", "23")
+        )
+    }
+
+    @Test
+    fun parseMultiple() {
+        assertThat(
+            DeviceSpec.parseSpecs("foo:23, bar:22")
+        ).containsExactly(
+            DeviceSpec("foo", "23"),
+            DeviceSpec("bar", "22")
+        )
+    }
+
+    @Test(
+        expected = IllegalArgumentException::class
+    )
+    fun parseEmpty() {
+        assertThat(
+            DeviceSpec.parseSpecs("")
+        ).isEmpty()
+    }
+
+    @Test(
+        expected = IllegalArgumentException::class
+    )
+    fun invalidSpec_noSdk() {
+        assertThat(
+            DeviceSpec.parseSpecs("a:")
+        ).isEmpty()
+    }
+
+    @Test(
+        expected = IllegalArgumentException::class
+    )
+    fun invalidSpec_noId() {
+        assertThat(
+            DeviceSpec.parseSpecs(":")
+        ).isEmpty()
+    }
+}

--- a/AndroidXCI/cli/src/test/kotlin/dev/androidx/ci/cli/DeviceSpecTest.kt
+++ b/AndroidXCI/cli/src/test/kotlin/dev/androidx/ci/cli/DeviceSpecTest.kt
@@ -52,17 +52,13 @@ class DeviceSpecTest {
         expected = IllegalArgumentException::class
     )
     fun invalidSpec_noSdk() {
-        assertThat(
-            DeviceSpec.parseSpecs("a:")
-        ).isEmpty()
+        DeviceSpec.parseSpecs("a:")
     }
 
     @Test(
         expected = IllegalArgumentException::class
     )
     fun invalidSpec_noId() {
-        assertThat(
-            DeviceSpec.parseSpecs(":")
-        ).isEmpty()
+        DeviceSpec.parseSpecs(":")
     }
 }

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,22 @@ inputs:
   output-folder:
     description: 'The output folder to download results into'
     required: true
+  device-specs:
+    description: 'Specs for devices. e.g. redfin:30, sailfish:25'
+    required: true
+  log-file:
+    description: 'Log file to export test runner logs.'
+    required: false
+  artifact-name-filter-regex:
+    description: 'A regex (kotlin) to filter artifact names when looking for APKs.'
+    required: false
+  gcp-bucket-name:
+    description: 'The name of the GCP Cloud Storage bucket that will be used to keep artifacts and results'
+    required: true
+  gcp-bucket-path:
+    description: 'The folder to use inside the bucket'
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -26,3 +42,8 @@ runs:
         ANDROIDX_TARGET_RUN_ID: ${{ github.event.workflow_run.id || inputs.target-run-id }}
         ANDROIDX_HOST_RUN_ID: ${{ github.run_id }}
         ANDROIDX_OUTPUT_FOLDER: ${{ inputs.output-folder }}
+        ANDROIDX_DEVICE_SPECS: ${{ inputs.device-specs }}
+        ANDROIDX_LOG_FILE: ${{ inputs.log-file }}
+        ANDROIDX_ARTIFACT_NAME_FILTER_REGEX: ${{ inputs.artifact-name-filter-regex }}
+        ANDROIDX_BUCKET_NAME: ${{ inputs.gcp-bucket-name }}
+        ANDROIDX_BUCKET_PATH: ${{ inputs.gcp-bucket-path }}


### PR DESCRIPTION
This CL expands the CI action to receive more parameters and hardcode
less values to be more usable from outside.

* Added log-file(optional) to let caller specify a log file location outside the
output directory.

* Added device-specs to be able to pass list of device-api configurations
as an argument.

* Added artifact-name-regex (optional) that can be used to filter artifacts
by name. The list of artifacts from a github build might be many and downloading
all of them to look for APKs is silly. This parameter can be optimized to
reduce the # of artifacts that are searched.

* Added gcp-bucket-name to specify the gcp butket name as an argument, instead
of the previously hardcoded value.

* Added gcp-bucket-path to specify the path in the bucket, instead of the
previously hardcoded value.