### PR TITLE
Double timeout for tests and enable video

### DIFF
--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestMatrixStore.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestMatrixStore.kt
@@ -158,7 +158,8 @@ internal class TestMatrixStore(
             projectId = firebaseProjectId,
             flakyTestAttempts = 2,
             testSpecification = TestSpecification(
-                disableVideoRecording = true,
+                testTimeout = "2700s", // Limit for physical devices.
+                disableVideoRecording = false,
                 androidInstrumentationTest = AndroidInstrumentationTest(
                     appApk = FileReference(
                         gcsPath = appApk.gcsPath.path


### PR DESCRIPTION
Fragment tests after introducing leak canary were timing out, and this way making it difficult to figure out where the leaks were coming from. I'm not sure if it's due to it taking longer if LeakCanary fails and needs to dump heap info + trace the leak. The last successful run took 28m, so increasing it to 30m.

I also found the video quite useful for determining whether the device hung up on a single test, got into a bad state, or if the tests were legitimately taking that long, so have also enabled that.

See b/256188823 for links to the last successful run with these params. I didn't want to post the link here since it is internal.

This is released as v0.09.