### PR TITLE
sort properties of classes

### DIFF
--- a/AndroidXCI/ftlModelBuilder/src/main/kotlin/dev/androidx/ci/codegen/DiscoveryDocumentModelGenerator.kt
+++ b/AndroidXCI/ftlModelBuilder/src/main/kotlin/dev/androidx/ci/codegen/DiscoveryDocumentModelGenerator.kt
@@ -89,6 +89,7 @@ internal class DiscoveryDocumentModelGenerator(
             .build()
         val moshi = Moshi.Builder()
             .add(KotlinJsonAdapterFactory())
+            .add(SortedMapAdapter.FACTORY)
             .build()
         val discoveryAdapter = moshi.adapter(DiscoveryDto::class.java).lenient()
         return client.newCall(request).execute().use { response ->

--- a/AndroidXCI/ftlModelBuilder/src/main/kotlin/dev/androidx/ci/codegen/Dtos.kt
+++ b/AndroidXCI/ftlModelBuilder/src/main/kotlin/dev/androidx/ci/codegen/Dtos.kt
@@ -27,7 +27,6 @@ import java.lang.reflect.Type
 import java.util.SortedMap
 import java.util.TreeMap
 
-
 // see: https://developers.google.com/discovery/v1/reference/apis
 /**
  * The root discovery class

--- a/AndroidXCI/ftlModelBuilder/src/main/kotlin/dev/androidx/ci/codegen/Dtos.kt
+++ b/AndroidXCI/ftlModelBuilder/src/main/kotlin/dev/androidx/ci/codegen/Dtos.kt
@@ -17,13 +17,23 @@
 package dev.androidx.ci.codegen
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.util.SortedMap
+import java.util.TreeMap
+
 
 // see: https://developers.google.com/discovery/v1/reference/apis
 /**
  * The root discovery class
  */
 internal class DiscoveryDto(
-    val schemas: Map<String, SchemaDto>
+    val schemas: SortedMap<String, SchemaDto>
 )
 
 /**
@@ -36,7 +46,9 @@ internal data class SchemaDto(
      */
     val type: String,
     val description: String? = null,
-    val properties: Map<String, PropertyDto>? = null
+    // discovery documents are not stable hence we keep properties
+    // sorted by name.
+    val properties: SortedMap<String, PropertyDto>? = null
 ) {
     fun isObject() = type == "object"
 }
@@ -51,3 +63,45 @@ internal data class PropertyDto(
     val items: PropertyDto? = null,
     val format: String? = null
 )
+
+/**
+ * A moshi adapter for generic SortedMaps that delegates to moshi's map
+ * adapter.
+ */
+internal class SortedMapAdapter<K, V>(
+    private val mapAdapter: JsonAdapter<Map<K, V>>
+) : JsonAdapter<SortedMap<K, V>>() {
+    override fun fromJson(reader: JsonReader): SortedMap<K, V>? {
+        val map = mapAdapter.fromJson(reader) ?: return null
+        return TreeMap(map)
+    }
+
+    override fun toJson(writer: JsonWriter, value: SortedMap<K, V>?) {
+        mapAdapter.toJson(value)
+    }
+
+    companion object {
+        val FACTORY = object : Factory {
+            override fun create(
+                type: Type,
+                annotations: MutableSet<out Annotation>,
+                moshi: Moshi
+            ): JsonAdapter<*>? {
+                if (annotations.isNotEmpty()) return null
+                val rawType: Class<*> = Types.getRawType(type)
+                if (rawType != SortedMap::class.java) return null
+                if (type is ParameterizedType) {
+                    val key = type.actualTypeArguments[0]
+                    val value = type.actualTypeArguments[1]
+                    val mapType = Types.newParameterizedType(
+                        Map::class.java,
+                        key,
+                        value
+                    )
+                    return SortedMapAdapter<Any, Any>(moshi.adapter(mapType))
+                }
+                return null
+            }
+        }
+    }
+}

--- a/AndroidXCI/ftlModelBuilder/src/test/kotlin/dev/androidx/ci/codegen/CodeGenTest.kt
+++ b/AndroidXCI/ftlModelBuilder/src/test/kotlin/dev/androidx/ci/codegen/CodeGenTest.kt
@@ -1,0 +1,76 @@
+package dev.androidx.ci.codegen
+
+import com.google.common.truth.Truth.assertThat
+import okio.Buffer
+import org.intellij.lang.annotations.Language
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class CodeGenTest {
+    @get:Rule
+    val tmpDir = TemporaryFolder()
+
+    @Test
+    fun generateCode() {
+        val firstOut = generate("""
+            {
+              "schemas": {
+                "MyClass": {
+                  "id": "MyClass",
+                  "type": "object",
+                  "properties": {
+                    "aProp": {
+                      "type": "integer"
+                    },
+                    "bProp": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            } 
+        """.trimIndent())
+        val secondOut = generate("""
+            {
+              "schemas": {
+                "MyClass": {
+                  "id": "MyClass",
+                  "type": "object",
+                  "properties": {
+                    "bProp": {
+                      "type": "string"
+                    },
+                    "aProp": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            } 
+        """.trimIndent())
+
+        assertThat(
+            firstOut.readText(Charsets.UTF_8)
+        ).isEqualTo(secondOut.readText(Charsets.UTF_8))
+    }
+
+    private fun generate(
+        @Language("json")
+        json: String
+    ): File {
+        val outDir = tmpDir.newFolder()
+        val buffer = Buffer()
+        buffer.writeUtf8(json)
+        val generator = DiscoveryDocumentModelGenerator(
+            outDir = outDir,
+            readDiscoverySource = { block ->
+                block(buffer)
+            },
+            pkg = "foo.bar",
+        )
+        generator.generate()
+        return outDir.walkTopDown().filter { it.isFile && it.extension == "kt" }.single()
+    }
+}

--- a/AndroidXCI/ftlModelBuilder/src/test/kotlin/dev/androidx/ci/codegen/CodeGenTest.kt
+++ b/AndroidXCI/ftlModelBuilder/src/test/kotlin/dev/androidx/ci/codegen/CodeGenTest.kt
@@ -14,7 +14,8 @@ class CodeGenTest {
 
     @Test
     fun generateCode() {
-        val firstOut = generate("""
+        val firstOut = generate(
+            """
             {
               "schemas": {
                 "MyClass": {
@@ -31,8 +32,10 @@ class CodeGenTest {
                 }
               }
             } 
-        """.trimIndent())
-        val secondOut = generate("""
+            """.trimIndent()
+        )
+        val secondOut = generate(
+            """
             {
               "schemas": {
                 "MyClass": {
@@ -49,7 +52,8 @@ class CodeGenTest {
                 }
               }
             } 
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         assertThat(
             firstOut.readText(Charsets.UTF_8)

--- a/AndroidXCI/ftlModelBuilder/src/test/kotlin/dev/androidx/ci/codegen/SchemaProcessorTest.kt
+++ b/AndroidXCI/ftlModelBuilder/src/test/kotlin/dev/androidx/ci/codegen/SchemaProcessorTest.kt
@@ -18,6 +18,7 @@ package dev.androidx.ci.codegen
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import java.util.TreeMap
 
 class SchemaProcessorTest {
     @Test
@@ -26,7 +27,7 @@ class SchemaProcessorTest {
             id = "MyClass",
             type = "object",
             description = "escape me please % %T %S",
-            properties = emptyMap()
+            properties = TreeMap()
         )
         val processor = SchemaProcessor(
             schemas = listOf(schema),
@@ -56,7 +57,7 @@ class SchemaProcessorTest {
                     enum = listOf("A", "B", "C"),
                     enumDescriptions = listOf("aa", "bb")
                 )
-            )
+            ).let { TreeMap(it) }
         )
         val processor = SchemaProcessor(
             schemas = listOf(schema),


### PR DESCRIPTION
discovery docs do not have a stable structure hence the code we generate might change between re-runs. This change ensures that we always sort properties to avoid generating different code for the same schema.