### PR TITLE
Disable performance metrics

### DIFF
--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestMatrixStore.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestMatrixStore.kt
@@ -176,6 +176,7 @@ internal class TestMatrixStore(
             testSpecification = TestSpecification(
                 testTimeout = "2700s", // Limit for physical devices.
                 disableVideoRecording = false,
+                disablePerformanceMetrics = true, // Not a useful feature for androidx
                 androidInstrumentationTest = AndroidInstrumentationTest(
                     appApk = FileReference(
                         gcsPath = appApk.gcsPath.path
@@ -185,7 +186,7 @@ internal class TestMatrixStore(
                     ),
                     shardingOption = sharding
                 ),
-                testSetup = deviceSetup?.toTestSetup()
+                testSetup = deviceSetup?.toTestSetup(),
             ),
             clientInfo = clientInfo,
             environmentMatrix = environmentMatrix,


### PR DESCRIPTION
https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run#--performance-metrics This feature is not useful for functional testing that our projects need.