### PR TITLE
Fixing test matrix store

### DIFF
--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestMatrixStore.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestMatrixStore.kt
@@ -29,7 +29,6 @@ import dev.androidx.ci.generated.ftl.ResultStorage
 import dev.androidx.ci.generated.ftl.ShardingOption
 import dev.androidx.ci.generated.ftl.TestMatrix
 import dev.androidx.ci.generated.ftl.TestSpecification
-import dev.androidx.ci.generated.ftl.ToolResultsExecution
 import dev.androidx.ci.generated.ftl.ToolResultsHistory
 import dev.androidx.ci.testRunner.dto.TestRun
 import dev.androidx.ci.testRunner.dto.toEntity
@@ -198,11 +197,6 @@ internal class TestMatrixStore(
                 toolResultsHistory = ToolResultsHistory(
                     projectId = firebaseProjectId,
                     historyId = historyId
-                ),
-                toolResultsExecution = ToolResultsExecution(
-                    executionId = UUID.randomUUID().toString(),
-                    historyId = historyId,
-                    projectId = firebaseProjectId
                 )
             )
         )


### PR DESCRIPTION
Removed `toolResultsExecution` from the actual `TestMatrixStore`.

Updated test to use `fakeFirebaseTestLabApi` to create the fake tesMatrix where we can pass in values for `toolResultsExecution`.