### PR TITLE
Cache results for getExecution steps to reduce number of apis calls

### DIFF
--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/gcloud/GoogleCloudApi.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/gcloud/GoogleCloudApi.kt
@@ -77,7 +77,7 @@ internal interface GoogleCloudApi {
     /**
      * Walks all entries under the given [gcsPath].
      */
-    suspend fun walkEntires(gcsPath: GcsPath): Sequence<BlobVisitor>
+    suspend fun walkEntries(gcsPath: GcsPath): Sequence<BlobVisitor>
 }
 
 /**
@@ -91,7 +91,7 @@ internal suspend fun GoogleCloudApi.download(
     target: File,
     filter: (String) -> Boolean
 ) {
-    walkEntires(gcsPath).filter { visitor ->
+    walkEntries(gcsPath).filter { visitor ->
         filter(visitor.relativePath)
     }.forEach { visitor ->
         val targetFile = if (visitor.isRoot()) {
@@ -159,7 +159,7 @@ private class GoogleCloudApiImpl(
         GcsPath.create(config.bucketName, artifactBucketPath)
     }
 
-    override suspend fun walkEntires(
+    override suspend fun walkEntries(
         gcsPath: GcsPath
     ): Sequence<BlobVisitor> {
         val blobId = gcsPath.blobId
@@ -222,16 +222,16 @@ private class GoogleCloudApiImpl(
 }
 
 /**
- * Provides access to a Blob returned from a [GoogleCloudApi.walkEntires] method.
+ * Provides access to a Blob returned from a [GoogleCloudApi.walkEntries] method.
  */
 internal interface BlobVisitor {
     /**
-     * Returns true if this Blob is the root blob that matches the `gcsPath` parameter of [GoogleCloudApi.walkEntires].
+     * Returns true if this Blob is the root blob that matches the `gcsPath` parameter of [GoogleCloudApi.walkEntries].
      */
     fun isRoot() = relativePath.isEmpty()
 
     /**
-     * Returns the relative path of the blob wrt to the `gcsPath` parameter of [GoogleCloudApi.walkEntires].
+     * Returns the relative path of the blob wrt to the `gcsPath` parameter of [GoogleCloudApi.walkEntries].
      */
     val relativePath: String
 

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerService.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerService.kt
@@ -91,6 +91,11 @@ interface TestRunnerService {
      */
     suspend fun getTestMatrixResults(testMatrix: TestMatrix): List<TestRunResult>?
 
+    /**
+     * Gets the mapping tests to logcats for the given [testMatrix].
+     */
+    suspend fun getTestMatrixLogcats(testMatrix: TestMatrix): MutableMap<TestIdentifier, ResultFileResource>?
+
     companion object {
         /**
          * Creates an implementation of [TestRunnerService].
@@ -236,7 +241,13 @@ interface TestRunnerService {
          * Run number associated with the test case run
          */
         public val runNumber: Int = 0
-    )
+    ) {
+        override fun toString(): String {
+            return buildString {
+                append("$className#$name#$runNumber")
+            }
+        }
+    }
 
     /**
      * Represents the result of a [TestMatrix].
@@ -289,10 +300,5 @@ interface TestRunnerService {
          * XML result files produced by the test.
          */
         val xmlResults: List<ResultFileResource>
-
-        /**
-         * Test case log files produced by the test.
-         */
-        val testCaseLogcats: Map<TestIdentifier, ResultFileResource>
     }
 }

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImpl.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImpl.kt
@@ -187,21 +187,21 @@ internal class TestRunnerServiceImpl internal constructor(
         var testCaseLogcatBlobs = mutableMapOf<TestRunnerService.TestIdentifier, TestRunnerService.ResultFileResource>()
         val resultPath = testMatrix.resultStorage.googleCloudStorage.gcsPath
 
-        //get cached result if available, else invoke tool results apis to get test execution steps and store them in glcoud bucket
+        // get cached result if available, else invoke tool results apis to get test execution steps and store them in glcoud bucket
         val logcatsFilePath = "$resultPath/logcats"
         val logcatsRelativePath = logcatsFilePath.substringAfter("gs://").substringAfter("/")
-        if(googleCloudApi.existingFilePath(logcatsRelativePath) != null) {
+        if (googleCloudApi.existingFilePath(logcatsRelativePath) != null) {
             googleCloudApi.walkEntries(GcsPath(logcatsFilePath)).first().obtainInputStream().reader().readLines().forEach {
                 val className = it.split("#")[0]
                 val name = it.split("#")[1]
                 val runNumber = it.split("#")[2]
                 val path = it.split("#")[3]
                 testCaseLogcatBlobs[
-                        TestRunnerService.TestIdentifier(
-                            className,
-                            name,
-                            runNumber.toInt()
-                        )
+                    TestRunnerService.TestIdentifier(
+                        className,
+                        name,
+                        runNumber.toInt()
+                    )
                 ] = ResultFileResourceImpl(googleCloudApi.walkEntries(GcsPath(path)).first())
             }
         } else {

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImpl.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImpl.kt
@@ -122,7 +122,7 @@ internal class TestRunnerServiceImpl internal constructor(
         gcsPath: String = "gs://androidx-ftl-test-results/github-ci-action/ftl"
     ): Sequence<BlobVisitor> {
         val path = GcsPath(path = gcsPath)
-        return googleCloudApi.walkEntires(path)
+        return googleCloudApi.walkEntries(path)
     }
 
     internal suspend fun findResultFiles(
@@ -151,7 +151,7 @@ internal class TestRunnerServiceImpl internal constructor(
         // redfin-30-en-portrait_rerun_2/logcat
         // redfin-30-en-portrait_rerun_2/test_result_1.xml
 
-        googleCloudApi.walkEntires(
+        googleCloudApi.walkEntries(
             gcsPath = resultPath
         ).forEach { visitor ->
             val fileName = visitor.fileName
@@ -191,7 +191,7 @@ internal class TestRunnerServiceImpl internal constructor(
         val logcatsFilePath = "$resultPath/logcats"
         val logcatsRelativePath = logcatsFilePath.substringAfter("gs://").substringAfter("/")
         if(googleCloudApi.existingFilePath(logcatsRelativePath) != null) {
-            googleCloudApi.walkEntires(GcsPath(logcatsFilePath)).first().obtainInputStream().reader().readLines().forEach {
+            googleCloudApi.walkEntries(GcsPath(logcatsFilePath)).first().obtainInputStream().reader().readLines().forEach {
                 val className = it.split("#")[0]
                 val name = it.split("#")[1]
                 val runNumber = it.split("#")[2]
@@ -202,13 +202,13 @@ internal class TestRunnerServiceImpl internal constructor(
                             name,
                             runNumber.toInt()
                         )
-                ] = ResultFileResourceImpl(googleCloudApi.walkEntires(GcsPath(path)).first())
+                ] = ResultFileResourceImpl(googleCloudApi.walkEntries(GcsPath(path)).first())
             }
         } else {
             fun BlobVisitor.fullDeviceId() = relativePath.substringBefore('/', "")
             val steps = testExecutionStore.getTestExecutionSteps(testMatrix)
             val out: java.lang.StringBuilder = StringBuilder()
-            googleCloudApi.walkEntires(
+            googleCloudApi.walkEntries(
                 gcsPath = GcsPath(resultPath)
             ).forEach { visitor ->
                 if (visitor.fileName.endsWith(LOGCAT_FILE_NAME_SUFFIX)) {

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeGoogleCloudApi.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/fake/FakeGoogleCloudApi.kt
@@ -48,7 +48,7 @@ internal class FakeGoogleCloudApi(
         return path
     }
 
-    override suspend fun walkEntires(gcsPath: GcsPath): Sequence<BlobVisitor> {
+    override suspend fun walkEntries(gcsPath: GcsPath): Sequence<BlobVisitor> {
         return artifacts.asSequence().filter { entry ->
             entry.key.path.startsWith(gcsPath.path)
         }.map { entry ->

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerServicePlayground.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerServicePlayground.kt
@@ -57,7 +57,7 @@ internal class TestRunnerServicePlayground {
         val testMatrixId = "matrix-hzjx70s88liva"
         val testMatrix = subject.getTestMatrix(testMatrixId)
         if (testMatrix != null) {
-            subject.findResultFiles(gcsPath, testMatrix).forEach {
+            subject.findResultFiles(gcsPath).forEach {
                 println(it)
             }
         }


### PR DESCRIPTION
Cache results for getExecution steps to reduce number of tools results apis calls.