### PR TITLE
Add test scheduler to support AndroidTest json files

### DIFF
--- a/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
+++ b/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
@@ -128,6 +128,16 @@ private class Cli : CliktCommand() {
         envvar = "ANDROIDX_BUCKET_PATH"
     ).required()
 
+    val useTestConfigFiles by option(
+        help = """
+            Internal for AndroidX.
+            If set, the action will look for json files matching *AndroidTest.json
+            See https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:buildSrc/private/src/main/kotlin/androidx/build/testConfiguration/AndroidTestConfigBuilder.kt
+            for contents of the file.
+        """.trimIndent(),
+        envvar = "ANDROIDX_USE_TEST_CONFIG_FILES"
+    )
+
     override fun run() {
         logFile?.let(::configureLogger)
         val repoParts = githubRepository.split("/")
@@ -155,7 +165,8 @@ private class Cli : CliktCommand() {
                     ?.let(::createDevicePicker),
                 artifactNameFilter = artifactNameFilter,
                 bucketName = gcpBucketName,
-                bucketPath = gcpBucketPath
+                bucketPath = gcpBucketPath,
+                useTestConfigFiles = useTestConfigFiles?.toBoolean() ?: false,
             )
             testRunner.runTests()
         }

--- a/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
+++ b/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
@@ -132,10 +132,17 @@ private class Cli : CliktCommand() {
         help = """
             Internal for AndroidX.
             If set, the action will look for json files matching *AndroidTest.json
-            See https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:buildSrc/private/src/main/kotlin/androidx/build/testConfiguration/AndroidTestConfigBuilder.kt
-            for contents of the file.
+            See TestScheduler.TestRunConfig for the json file structure.
         """.trimIndent(),
         envvar = "ANDROIDX_USE_TEST_CONFIG_FILES"
+    )
+
+    val testSuiteTags by option(
+        help = """
+            Comma separated list of testSuiteTags that should be run.
+            Only used if `useTestConfigFiles` is set to true.
+        """.trimIndent(),
+        envvar = "ANDROIDX_TEST_SUITE_TAGS"
     )
 
     override fun run() {
@@ -167,6 +174,7 @@ private class Cli : CliktCommand() {
                 bucketName = gcpBucketName,
                 bucketPath = gcpBucketPath,
                 useTestConfigFiles = useTestConfigFiles?.toBoolean() ?: false,
+                testSuiteTags = testSuiteTags?.split(',')?.map { it.trim() } ?: emptyList()
             )
             testRunner.runTests()
         }

--- a/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
+++ b/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
@@ -131,16 +131,19 @@ private class Cli : CliktCommand() {
     val useTestConfigFiles by option(
         help = """
             Internal for AndroidX.
-            If set, the action will look for json files matching *AndroidTest.json
+            If set, the action will look for json files matching *AndroidTest.json inside the Github archives.
             See TestScheduler.TestRunConfig for the json file structure.
+            Defaults to false.
         """.trimIndent(),
         envvar = "ANDROIDX_USE_TEST_CONFIG_FILES"
     )
 
     val testSuiteTags by option(
         help = """
+            Internal for AndroidX.
             Comma separated list of testSuiteTags that should be run.
             Only used if `useTestConfigFiles` is set to true.
+            Defaults to empty list, which runs all testSuiteTags.
         """.trimIndent(),
         envvar = "ANDROIDX_TEST_SUITE_TAGS"
     )

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunner.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunner.kt
@@ -113,6 +113,8 @@ class TestRunner internal constructor(
                 .filter(githubArtifactFilter)
                 .flatMap { artifact ->
                     testScheduler.enqueueTests(artifact)
+                }.also { testMatrices ->
+                    logger.info { "started all tests for $testMatrices" }
                 }
             logger.info("will wait for test results")
             testLabController.collectTestResults(
@@ -208,7 +210,7 @@ class TestRunner internal constructor(
                 targetRunId = targetRunId,
                 hostRunId = hostRunId,
                 devicePicker = devicePicker,
-                testSchedulerFactory = TestScheduler.getFactory(useTestConfigFiles, testSuiteTags)
+                testSchedulerFactory = TestScheduler.createFactory(useTestConfigFiles, testSuiteTags)
             )
         }
 

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunner.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunner.kt
@@ -157,7 +157,8 @@ class TestRunner internal constructor(
             bucketPath: String,
             devicePicker: DevicePicker? = null,
             artifactNameFilter: (String) -> Boolean = { true },
-            useTestConfigFiles: Boolean
+            useTestConfigFiles: Boolean,
+            testSuiteTags: List<String>
         ): TestRunner {
             val credentials = ServiceAccountCredentials.fromStream(
                 googleCloudCredentials.byteInputStream(Charsets.UTF_8)
@@ -207,7 +208,7 @@ class TestRunner internal constructor(
                 targetRunId = targetRunId,
                 hostRunId = hostRunId,
                 devicePicker = devicePicker,
-                testSchedulerFactory = TestScheduler.getFactory(useTestConfigFiles)
+                testSchedulerFactory = TestScheduler.getFactory(useTestConfigFiles, testSuiteTags)
             )
         }
 

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunner.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunner.kt
@@ -25,18 +25,11 @@ import dev.androidx.ci.gcloud.GoogleCloudApi
 import dev.androidx.ci.generated.ftl.TestMatrix
 import dev.androidx.ci.github.GithubApi
 import dev.androidx.ci.github.dto.ArtifactsResponse
-import dev.androidx.ci.github.zipArchiveStream
 import dev.androidx.ci.testRunner.vo.TestResult
-import dev.androidx.ci.testRunner.vo.UploadedApk
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import org.apache.logging.log4j.kotlin.logger
 import java.io.File
 import java.util.concurrent.TimeUnit
-import java.util.zip.ZipEntry
 
 /**
  * Main class that is responsible to run tests, download reports etc.
@@ -75,7 +68,11 @@ class TestRunner internal constructor(
     /**
      * Device picker
      */
-    private val devicePicker: DevicePicker? = null
+    private val devicePicker: DevicePicker? = null,
+    /**
+     * The actual class that will decide which tests to run out of the artifacts
+     */
+    testSchedulerFactory: TestScheduler.Factory,
 ) {
     private val logger = logger()
     private val testMatrixStore = TestMatrixStore(
@@ -96,6 +93,12 @@ class TestRunner internal constructor(
         hostRunId = hostRunId,
         targetRunId = targetRunId
     )
+    private val testScheduler = testSchedulerFactory.create(
+        githubApi = githubApi,
+        firebaseTestLabController = testLabController,
+        apkStore = apkStore,
+        devicePicker = devicePicker
+    )
 
     /**
      * Runs all the test. This never throws, instead, returns an error result if something goes
@@ -109,16 +112,7 @@ class TestRunner internal constructor(
             val allTestMatrices = artifactsResponse.artifacts
                 .filter(githubArtifactFilter)
                 .flatMap { artifact ->
-                    logger.info { "will upload apks for $artifact" }
-                    val uploadedApks = uploadApksToGoogleCloud(artifact)
-                    logger.info { "will start tests for these apks: $uploadedApks" }
-                    testLabController.pairAndStartTests(
-                        apks = uploadedApks,
-                        placeholderApk = apkStore.getPlaceholderApk(),
-                        devicePicker = devicePicker
-                    ).also { testMatrices ->
-                        logger.info { "started all tests for $testMatrices" }
-                    }
+                    testScheduler.enqueueTests(artifact)
                 }
             logger.info("will wait for test results")
             testLabController.collectTestResults(
@@ -148,30 +142,6 @@ class TestRunner internal constructor(
         return result
     }
 
-    private suspend fun uploadApksToGoogleCloud(artifact: ArtifactsResponse.Artifact): List<UploadedApk> {
-        return coroutineScope {
-            val uploads = githubApi.zipArchiveStream(
-                path = artifact.archiveDownloadUrl,
-                unwrapNestedZipEntries = true
-            ).filter {
-                it.entry.name.endsWith(".apk")
-            }.map {
-                uploadApkToGcsAsync(it.entry, it.bytes)
-            }.toList()
-            uploads.awaitAll()
-        }
-    }
-
-    private fun CoroutineScope.uploadApkToGcsAsync(
-        zipEntry: ZipEntry,
-        bytes: ByteArray,
-    ) = async {
-        apkStore.uploadApk(
-            name = zipEntry.name,
-            bytes = bytes
-        )
-    }
-
     companion object {
         internal const val RESULT_JSON_FILE_NAME = "result.json"
         fun create(
@@ -187,6 +157,7 @@ class TestRunner internal constructor(
             bucketPath: String,
             devicePicker: DevicePicker? = null,
             artifactNameFilter: (String) -> Boolean = { true },
+            useTestConfigFiles: Boolean
         ): TestRunner {
             val credentials = ServiceAccountCredentials.fromStream(
                 googleCloudCredentials.byteInputStream(Charsets.UTF_8)
@@ -235,7 +206,8 @@ class TestRunner internal constructor(
                 outputFolder = outputFolder,
                 targetRunId = targetRunId,
                 hostRunId = hostRunId,
-                devicePicker = devicePicker
+                devicePicker = devicePicker,
+                testSchedulerFactory = TestScheduler.getFactory(useTestConfigFiles)
             )
         }
 

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestScheduler.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestScheduler.kt
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.androidx.ci.testRunner
+
+import com.squareup.moshi.Moshi
+import dev.androidx.ci.generated.ftl.TestMatrix
+import dev.androidx.ci.github.GithubApi
+import dev.androidx.ci.github.ZipEntryScope
+import dev.androidx.ci.github.dto.ArtifactsResponse
+import dev.androidx.ci.github.zipArchiveStream
+import dev.androidx.ci.testRunner.vo.DeviceSetup
+import dev.androidx.ci.testRunner.vo.UploadedApk
+import dev.zacsweers.moshix.reflect.MetadataKotlinJsonAdapterFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import org.apache.logging.log4j.kotlin.logger
+import java.util.zip.ZipEntry
+
+/**
+ * Helper class to select which tests to run out of an artifact.
+ *
+ * There are 2 implementations:
+ * 1) RunAllTests will select all APKs, pair them based on the names and try to run.
+ * 2) ByTestConfig will parse the TestConfig.json files and only run tests specified in that list.
+ */
+internal sealed interface TestScheduler {
+    suspend fun enqueueTests(
+        artifact: ArtifactsResponse.Artifact,
+    ): List<TestMatrix>
+    class PairAndRunAllApks(
+        private val githubApi: GithubApi,
+        private val firebaseTestLabController: FirebaseTestLabController,
+        private val apkStore: ApkStore,
+        private val devicePicker: DevicePicker?
+    ) : TestScheduler {
+        override suspend fun enqueueTests(
+            artifact: ArtifactsResponse.Artifact
+        ): List<TestMatrix> {
+            val apks = uploadApksToGoogleCloud(githubApi, artifact)
+            return firebaseTestLabController.pairAndStartTests(
+                apks = apks,
+                placeholderApk = apkStore.getPlaceholderApk(),
+                devicePicker = devicePicker
+            )
+        }
+
+        private suspend fun uploadApksToGoogleCloud(
+            githubApi: GithubApi,
+            artifact: ArtifactsResponse.Artifact
+        ): List<UploadedApk> {
+            return coroutineScope {
+                val uploads = githubApi.zipArchiveStream(
+                    path = artifact.archiveDownloadUrl,
+                    unwrapNestedZipEntries = true
+                ).filter {
+                    it.entry.name.endsWith(".apk")
+                }.map {
+                    uploadApkToGcsAsync(it.entry, it.bytes)
+                }.toList()
+                uploads.awaitAll()
+            }
+        }
+
+        private fun CoroutineScope.uploadApkToGcsAsync(
+            zipEntry: ZipEntry,
+            bytes: ByteArray,
+        ) = async {
+            apkStore.uploadApk(
+                name = zipEntry.name,
+                bytes = bytes
+            )
+        }
+
+        object Factory : TestScheduler.Factory {
+            override fun create(
+                githubApi: GithubApi,
+                firebaseTestLabController: FirebaseTestLabController,
+                apkStore: ApkStore,
+                devicePicker: DevicePicker?
+            ): TestScheduler {
+                return PairAndRunAllApks(
+                    githubApi = githubApi,
+                    firebaseTestLabController = firebaseTestLabController,
+                    apkStore = apkStore,
+                    devicePicker = devicePicker
+                )
+            }
+        }
+    }
+
+    class RunUsingTestRunConfig(
+        private val githubApi: GithubApi,
+        private val firebaseTestLabController: FirebaseTestLabController,
+        private val apkStore: ApkStore,
+        private val devicePicker: DevicePicker?
+    ) : TestScheduler {
+        override suspend fun enqueueTests(artifact: ArtifactsResponse.Artifact): List<TestMatrix> {
+            val testsToBeScheduled = githubApi.zipArchiveStream(
+                path = artifact.archiveDownloadUrl,
+                unwrapNestedZipEntries = true
+            ).filter {
+                it.entry.name.endsWith("AndroidTest.json")
+            }.mapNotNull {
+                adapter.fromJson(it.bytes.toString(Charsets.UTF_8))
+            }.filter { testRunConfig ->
+                // additional apks are not supported
+                testRunConfig.additionalApkKeys.isEmpty().also {
+                    if (!it) {
+                        logger.info {
+                            "TestRunConfigs with additional APKs are not supported. Skipping $testRunConfig"
+                        }
+                    }
+                }
+            }.map {
+                TestToBeScheduled(it)
+            }.toList()
+            githubApi.zipArchiveStream(
+                path = artifact.archiveDownloadUrl,
+                unwrapNestedZipEntries = true
+            ).filter {
+                it.entry.name.endsWith(".apk")
+            }.forEach { zipEntryScope ->
+                testsToBeScheduled.forEach {
+                    it.processZipEntry(apkStore, zipEntryScope)
+                }
+            }
+            return testsToBeScheduled.flatMap {
+                it.trySubmit(
+                    firebaseTestLabController = firebaseTestLabController,
+                    apkStore = apkStore,
+                    devicePicker = devicePicker
+                )
+            }
+        }
+
+        /**
+         * A mutable data structure that can collect / upload APKs out of a zip stream.
+         * It is created from a [TestRunConfig] and will be called with each zip entry to
+         * find its APKs. After the zip is parsed, it will be called to schedule its tests if possible.
+         */
+        class TestToBeScheduled(
+            val config: TestRunConfig
+        ) {
+            val appApk: PendingApk? = config.appApk?.let { appApk ->
+                config.appApkSha256?.let { sha256 ->
+                    PendingApk(name = appApk, sha256 = sha256)
+                }
+            }
+            val testApk: PendingApk = PendingApk(
+                name = config.testApk,
+                sha256 = config.testApkSha256
+            )
+
+            suspend fun trySubmit(
+                firebaseTestLabController: FirebaseTestLabController,
+                apkStore: ApkStore,
+                devicePicker: DevicePicker?
+            ): List<TestMatrix> {
+                val uploadedAppApk = if (appApk == null) {
+                    apkStore.getPlaceholderApk()
+                } else {
+                    appApk.apk.also {
+                        if (it == null) {
+                            logger.warn("Couldn't find apk for ${config.appApk}, skipping test")
+                        }
+                    }
+                }
+                val uploadedTestApk = testApk.apk
+                if (uploadedAppApk == null || uploadedTestApk == null) {
+                    logger.warn {
+                        """Skipping $config because we couldn't find either the app or test apk"""
+                    }
+                    return emptyList()
+                }
+                val instrumentationArguments =
+                    config.instrumentationArgs.map {
+                        DeviceSetup.InstrumentationArgument(
+                            key = it.key,
+                            value = it.value
+                        )
+                    }
+                return firebaseTestLabController.submitTests(
+                    appApk = uploadedAppApk,
+                    testApk = uploadedTestApk,
+                    clientInfo = null,
+                    sharding = null,
+                    deviceSetup = DeviceSetup(
+                        instrumentationArguments = instrumentationArguments
+                    ),
+                    devicePicker = devicePicker,
+                    pullScreenshots = false
+                )
+            }
+
+            suspend fun processZipEntry(
+                apkStore: ApkStore,
+                scope: ZipEntryScope
+            ) {
+                appApk?.processZipEntry(apkStore, scope)
+                testApk.processZipEntry(apkStore, scope)
+            }
+
+            class PendingApk(
+                val name: String,
+                val sha256: String
+            ) {
+                private var uploadedApk: UploadedApk? = null
+
+                val apk: UploadedApk?
+                    get() = uploadedApk
+
+                suspend fun processZipEntry(
+                    apkStore: ApkStore,
+                    scope: ZipEntryScope
+                ) {
+                    if (uploadedApk != null) {
+                        return
+                    }
+                    if (scope.entry.name == name) {
+                        val alreadyUploaded = apkStore.getUploadedApk(name, sha256)
+                        uploadedApk = alreadyUploaded ?: apkStore.uploadApk(name, scope.bytes)
+                    }
+                }
+            }
+        }
+
+        data class TestRunConfig(
+            val name: String,
+            val testApk: String,
+            val testApkSha256: String,
+            val appApk: String?,
+            val appApkSha256: String?,
+            val minSdkVersion: Int,
+            val instrumentationArgs: List<InstrumentationArg>,
+            val testSuiteTags: List<String>,
+            val additionalApkKeys: List<String>
+        )
+
+        data class InstrumentationArg(
+            val key: String,
+            val value: String
+        )
+
+        companion object {
+            private val moshi = Moshi.Builder()
+                .add(MetadataKotlinJsonAdapterFactory())
+                .build()
+            private val adapter = moshi.adapter(TestRunConfig::class.java)
+            val Factory = object : Factory {
+                override fun create(
+                    githubApi: GithubApi,
+                    firebaseTestLabController: FirebaseTestLabController,
+                    apkStore: ApkStore,
+                    devicePicker: DevicePicker?
+                ): TestScheduler {
+                    return RunUsingTestRunConfig(
+                        githubApi = githubApi,
+                        firebaseTestLabController = firebaseTestLabController,
+                        apkStore = apkStore,
+                        devicePicker = devicePicker
+                    )
+                }
+            }
+        }
+    }
+
+    interface Factory {
+        fun create(
+            githubApi: GithubApi,
+            firebaseTestLabController: FirebaseTestLabController,
+            apkStore: ApkStore,
+            devicePicker: DevicePicker?
+        ): TestScheduler
+    }
+    companion object {
+        private val logger = logger()
+        fun getFactory(
+            useTestConfigFiles: Boolean
+        ): Factory {
+            return if (useTestConfigFiles) {
+                RunUsingTestRunConfig.Factory
+            } else {
+                PairAndRunAllApks.Factory
+            }
+        }
+    }
+}

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerPlayground.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerPlayground.kt
@@ -90,7 +90,7 @@ internal class TestRunnerPlayground {
             },
             targetRunId = runId,
             hostRunId = runId,
-            testSchedulerFactory = TestScheduler.getFactory(useTestConfigFiles = false, testSuiteTags = emptyList())
+            testSchedulerFactory = TestScheduler.createFactory(useTestConfigFiles = false, testSuiteTags = emptyList())
         )
     }
 

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerPlayground.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerPlayground.kt
@@ -90,7 +90,7 @@ internal class TestRunnerPlayground {
             },
             targetRunId = runId,
             hostRunId = runId,
-            testSchedulerFactory = TestScheduler.getFactory(useTestConfigFiles = false)
+            testSchedulerFactory = TestScheduler.getFactory(useTestConfigFiles = false, testSuiteTags = emptyList())
         )
     }
 

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerPlayground.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerPlayground.kt
@@ -89,7 +89,8 @@ internal class TestRunnerPlayground {
                 it.name.contains("artifacts_navigation")
             },
             targetRunId = runId,
-            hostRunId = runId
+            hostRunId = runId,
+            testSchedulerFactory = TestScheduler.getFactory(useTestConfigFiles = false)
         )
     }
 

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerTest.kt
@@ -57,7 +57,8 @@ internal class TestRunnerTest {
             targetRunId = TARGET_RUN_ID,
             hostRunId = HOST_RUN_ID,
             datastoreApi = fakeBackend.datastoreApi,
-            outputFolder = outputFolder
+            outputFolder = outputFolder,
+            testSchedulerFactory = TestScheduler.getFactory(useTestConfigFiles = false)
         )
     }
 

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerTest.kt
@@ -61,7 +61,7 @@ internal class TestRunnerTest(
             hostRunId = HOST_RUN_ID,
             datastoreApi = fakeBackend.datastoreApi,
             outputFolder = outputFolder,
-            testSchedulerFactory = TestScheduler.getFactory(
+            testSchedulerFactory = TestScheduler.createFactory(
                 useTestConfigFiles = useTestConfigFiles,
                 testSuiteTags = emptyList()
             )

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,9 @@ inputs:
   use-test-config-files:
     description: 'An internal flag for androidx/androidx to use test config files in artifacts for selecting which tests to run'
     required: false
+  test-suite-tags:
+    description: 'A comma separated list of test suite tags to be run. Only used if use-test-config-files is true'
+    required: false
 
 runs:
   using: "composite"
@@ -55,3 +58,4 @@ runs:
         ANDROIDX_BUCKET_NAME: ${{ inputs.gcp-bucket-name }}
         ANDROIDX_BUCKET_PATH: ${{ inputs.gcp-bucket-path }}
         ANDROIDX_USE_TEST_CONFIG_FILES: ${{ inputs.use-test-config-files }}
+        ANDROIDX_TEST_SUITE_TAGS: ${{ inputs.test-suite-tags }}

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   gcp-bucket-path:
     description: 'The folder to use inside the bucket'
     required: true
+  use-test-config-files:
+    description: 'An internal flag for androidx/androidx to use test config files in artifacts for selecting which tests to run'
+    required: false
 
 runs:
   using: "composite"
@@ -51,3 +54,4 @@ runs:
         ANDROIDX_ARTIFACT_NAME_FILTER_REGEX: ${{ inputs.artifact-name-filter-regex }}
         ANDROIDX_BUCKET_NAME: ${{ inputs.gcp-bucket-name }}
         ANDROIDX_BUCKET_PATH: ${{ inputs.gcp-bucket-path }}
+        ANDROIDX_USE_TEST_CONFIG_FILES: ${{ inputs.use-test-config-files }}


### PR DESCRIPTION
This CL adds ability to parse AndroidTest json files in zip archives.
There are 2 new parameters to the action:

`use-test-config-files`  to enable it
`test-suite-tags` to specify test suite tags

The implementation is not as efficient as AndroidX.dev where we use a custom Zip file to load it lazily. We can consider moving that code to here but it is also not as big of a deal since the zip files here are much smaller.
