### PR TITLE
Fixing null check

### DIFF
--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerService.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerService.kt
@@ -98,7 +98,7 @@ interface TestRunnerService {
      * Returns null when the testMatrix is not complete,
      * and emptyMap if there are no screenshots associated with the test (non-screenshot tests)
      */
-    suspend fun getTestMatrixResultsScreenshots(
+    suspend fun getTestMatrixArtifacts(
         testMatrix: TestMatrix,
         testIdentifiers: List<TestIdentifier>
     ): Map<TestIdentifier, List<TestCaseArtifact>>?

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImpl.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImpl.kt
@@ -210,7 +210,8 @@ internal class TestRunnerServiceImpl internal constructor(
     private suspend fun findScreenshotFiles(
         resultPath: GcsPath,
         testIdentifiers: List<TestRunnerService.TestIdentifier>
-    ): Map< TestRunnerService.TestIdentifier, List<TestRunnerService.TestCaseArtifact>> {
+    ): Map< TestRunnerService.TestIdentifier, List<TestRunnerService.TestCaseArtifact>>? {
+        if(testIdentifiers.isEmpty()) return null
         val screenshotArtifactsBlobs = mutableMapOf<TestRunnerService.TestIdentifier, MutableList<TestRunnerService.TestCaseArtifact>>()
         val screenshotArtifacts: Map<TestRunnerService.TestIdentifier, List<TestRunnerService.TestCaseArtifact>>
         val testNames = testIdentifiers.associateBy { testIdentifier ->

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImpl.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImpl.kt
@@ -211,7 +211,7 @@ internal class TestRunnerServiceImpl internal constructor(
         resultPath: GcsPath,
         testIdentifiers: List<TestRunnerService.TestIdentifier>
     ): Map< TestRunnerService.TestIdentifier, List<TestRunnerService.TestCaseArtifact>>? {
-        if(testIdentifiers.isEmpty()) return null
+        if (testIdentifiers.isEmpty()) return null
         val screenshotArtifactsBlobs = mutableMapOf<TestRunnerService.TestIdentifier, MutableList<TestRunnerService.TestCaseArtifact>>()
         val screenshotArtifacts: Map<TestRunnerService.TestIdentifier, List<TestRunnerService.TestCaseArtifact>>
         val testNames = testIdentifiers.associateBy { testIdentifier ->

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImpl.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImpl.kt
@@ -213,7 +213,6 @@ internal class TestRunnerServiceImpl internal constructor(
     ): Map< TestRunnerService.TestIdentifier, List<TestRunnerService.TestCaseArtifact>>? {
         if (testIdentifiers.isEmpty()) return null
         val testArtifactsBlobs = mutableMapOf<TestRunnerService.TestIdentifier, MutableList<TestRunnerService.TestCaseArtifact>>()
-        val testArtifacts: Map<TestRunnerService.TestIdentifier, List<TestRunnerService.TestCaseArtifact>>
         val testNames = testIdentifiers.associateBy { testIdentifier ->
             "${testIdentifier.className}_${testIdentifier.name}"
         }
@@ -228,6 +227,9 @@ internal class TestRunnerServiceImpl internal constructor(
                     visitor.fileName.startsWith(testName)
                 }
                 val testIdentifier = testNames[testName]
+                println("filename =  ${visitor.fileName}")
+                println("testName = $testName")
+                println("testIdentifier = $testIdentifier")
                 if (testIdentifier != null) {
                     testArtifactsBlobs.getOrPut(testIdentifier) {
                         mutableListOf()
@@ -240,8 +242,7 @@ internal class TestRunnerServiceImpl internal constructor(
                 }
             }
         }
-        testArtifacts = testArtifactsBlobs
-        return testArtifacts
+        return testArtifactsBlobs
     }
 
     suspend fun getTestMatrixResults(

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImpl.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImpl.kt
@@ -207,13 +207,13 @@ internal class TestRunnerServiceImpl internal constructor(
         }
     }
 
-    private suspend fun findScreenshotFiles(
+    private suspend fun findArtifacts(
         resultPath: GcsPath,
         testIdentifiers: List<TestRunnerService.TestIdentifier>
     ): Map< TestRunnerService.TestIdentifier, List<TestRunnerService.TestCaseArtifact>>? {
         if (testIdentifiers.isEmpty()) return null
-        val screenshotArtifactsBlobs = mutableMapOf<TestRunnerService.TestIdentifier, MutableList<TestRunnerService.TestCaseArtifact>>()
-        val screenshotArtifacts: Map<TestRunnerService.TestIdentifier, List<TestRunnerService.TestCaseArtifact>>
+        val testArtifactsBlobs = mutableMapOf<TestRunnerService.TestIdentifier, MutableList<TestRunnerService.TestCaseArtifact>>()
+        val testArtifacts: Map<TestRunnerService.TestIdentifier, List<TestRunnerService.TestCaseArtifact>>
         val testNames = testIdentifiers.associateBy { testIdentifier ->
             "${testIdentifier.className}_${testIdentifier.name}"
         }
@@ -229,7 +229,7 @@ internal class TestRunnerServiceImpl internal constructor(
                 }
                 val testIdentifier = testNames[testName]
                 if (testIdentifier != null) {
-                    screenshotArtifactsBlobs.getOrPut(testIdentifier) {
+                    testArtifactsBlobs.getOrPut(testIdentifier) {
                         mutableListOf()
                     }.add(
                         TestRunnerService.TestCaseArtifact(
@@ -240,8 +240,8 @@ internal class TestRunnerServiceImpl internal constructor(
                 }
             }
         }
-        screenshotArtifacts = screenshotArtifactsBlobs
-        return screenshotArtifacts
+        testArtifacts = testArtifactsBlobs
+        return testArtifacts
     }
 
     suspend fun getTestMatrixResults(
@@ -251,12 +251,12 @@ internal class TestRunnerServiceImpl internal constructor(
         return getTestMatrixResults(testMatrix)
     }
 
-    suspend fun getTestMatrixResultsScreenshots(
+    suspend fun getTestMatrixArtifacts(
         testMatrixId: String,
         testIdentifiers: List<TestRunnerService.TestIdentifier>
     ): Map<TestRunnerService.TestIdentifier, List<TestRunnerService.TestCaseArtifact>>? {
         val testMatrix = testLabController.getTestMatrix(testMatrixId) ?: return null
-        return getTestMatrixResultsScreenshots(testMatrix, testIdentifiers)
+        return getTestMatrixArtifacts(testMatrix, testIdentifiers)
     }
 
     override suspend fun getTestMatrixResults(
@@ -267,13 +267,13 @@ internal class TestRunnerServiceImpl internal constructor(
         return findResultFiles(resultPath, testMatrix)
     }
 
-    override suspend fun getTestMatrixResultsScreenshots(
+    override suspend fun getTestMatrixArtifacts(
         testMatrix: TestMatrix,
         testIdentifiers: List<TestRunnerService.TestIdentifier>
     ): Map<TestRunnerService.TestIdentifier, List<TestRunnerService.TestCaseArtifact>>? {
         if (!testMatrix.isComplete()) return null
         val resultPath = GcsPath(testMatrix.resultStorage.googleCloudStorage.gcsPath)
-        return findScreenshotFiles(resultPath, testIdentifiers)
+        return findArtifacts(resultPath, testIdentifiers)
     }
 
     companion object {

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImplTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImplTest.kt
@@ -380,14 +380,14 @@ class TestRunnerServiceImplTest {
 
         assertThat(result.testRuns).hasSize(1)
         result.testRuns.first().let { testRun ->
-            val testIdentifier = TestRunnerService.TestIdentifier(
+            val testIdentifier1 = TestRunnerService.TestIdentifier(
                 className = "class1",
                 name = "name1",
                 runNumber = testRun.deviceRun.runNumber
             )
-            val screenshots = subject.getTestMatrixResultsScreenshots(
+            val screenshots1 = subject.getTestMatrixResultsScreenshots(
                 testMatrixId,
-                listOf(testIdentifier)
+                listOf(testIdentifier1)
             )
             assertThat(
                 testRun.deviceRun.deviceId
@@ -415,7 +415,7 @@ class TestRunnerServiceImplTest {
             )
             assertThat(
                 testRun.testCaseArtifacts[
-                    testIdentifier
+                    testIdentifier1
                 ]?.size
             ).isEqualTo(
                 1
@@ -423,7 +423,7 @@ class TestRunnerServiceImplTest {
             // step and logcat both have valid values for test1
             assertThat(
                 testRun.testCaseArtifacts[
-                    testIdentifier
+                    testIdentifier1
                 ]?.first {
                     it.resourceType == TestRunnerService.TestCaseArtifact.ResourceType.LOGCAT
                 }?.resultFileResource?.gcsPath.toString()
@@ -432,7 +432,7 @@ class TestRunnerServiceImplTest {
             )
             assertThat(
                 testRun.testCaseArtifacts[
-                    testIdentifier
+                    testIdentifier1
                 ]?.first {
                     it.resourceType == TestRunnerService.TestCaseArtifact.ResourceType.LOGCAT
                 }?.resultFileResource?.readFully()?.toString(Charsets.UTF_8)
@@ -440,21 +440,21 @@ class TestRunnerServiceImplTest {
                 "test1 logcat"
             )
             assertThat(
-                screenshots?.get(testIdentifier)?.count {
+                screenshots1?.get(testIdentifier1)?.count {
                     it.resourceType == TestRunnerService.TestCaseArtifact.ResourceType.PNG
                 }
             ).isEqualTo(
                 3
             )
             assertThat(
-                screenshots?.get(testIdentifier)?.count {
+                screenshots1?.get(testIdentifier1)?.count {
                     it.resourceType == TestRunnerService.TestCaseArtifact.ResourceType.TEXTPROTO
                 }
             ).isEqualTo(
                 1
             )
             assertThat(
-                screenshots?.get(testIdentifier)?.first {
+                screenshots1?.get(testIdentifier1)?.first {
                     it.resourceType == TestRunnerService.TestCaseArtifact.ResourceType.TEXTPROTO
                 }?.resultFileResource?.gcsPath.toString()
             ).isEqualTo(
@@ -471,6 +471,19 @@ class TestRunnerServiceImplTest {
                     )
                 ]
             ).isNull()
+            //No screenshots for test2
+            val testIdentifier2 = TestRunnerService.TestIdentifier(
+                className = "class2",
+                name = "name2",
+                runNumber = testRun.deviceRun.runNumber
+            )
+            val screenshots2 = subject.getTestMatrixResultsScreenshots(
+                testMatrixId,
+                listOf(testIdentifier2)
+            )
+            assertThat(
+                screenshots2
+            ).isEmpty()
             // logcat for test3 is missing from gcloud folder
             assertThat(
                 testRun.testCaseArtifacts[
@@ -481,7 +494,28 @@ class TestRunnerServiceImplTest {
                     )
                 ]
             ).isNull()
+            //No screenshots for test3 either
+            val testIdentifier3 = TestRunnerService.TestIdentifier(
+                className = "class2",
+                name = "name2",
+                runNumber = testRun.deviceRun.runNumber
+            )
+            val screenshots3 = subject.getTestMatrixResultsScreenshots(
+                testMatrixId,
+                listOf(testIdentifier3)
+            )
+            assertThat(
+                screenshots3
+            ).isEmpty()
         }
+        //check screenshots is null when list of testIdentifiers is empty
+        val screenshots = subject.getTestMatrixResultsScreenshots(
+            testMatrixId,
+            emptyList()
+        )
+        assertThat(
+            screenshots
+        ).isNull()
     }
 
     @Test

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImplTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImplTest.kt
@@ -332,6 +332,11 @@ class TestRunnerServiceImplTest {
             "$resultRelativePath/redfin-30-en-portrait/artifacts/sdcard/Android/data/test/cache/androidx_screenshots/class1_name1_emulator_goldResult.textproto",
             "class1 name1 emulator textproto".toByteArray(Charsets.UTF_8)
         )
+        // No test is associated with this artifact. findArtifacts should not throw errors, even when unexpected files are encountered
+        fakeBackend.fakeGoogleCloudApi.upload(
+            "$resultRelativePath/redfin-30-en-portrait/artifacts/sdcard/Android/data/test/cache/androidx_screenshots/class5_name5_emulator_goldResult.textproto",
+            "class5 name5 emulator textproto".toByteArray(Charsets.UTF_8)
+        )
 
         fakeToolsResultApi.addStep(
             projectId = fakeBackend.firebaseProjectId,

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImplTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImplTest.kt
@@ -471,7 +471,7 @@ class TestRunnerServiceImplTest {
                     )
                 ]
             ).isNull()
-            //No screenshots for test2
+            // No screenshots for test2
             val testIdentifier2 = TestRunnerService.TestIdentifier(
                 className = "class2",
                 name = "name2",
@@ -494,7 +494,7 @@ class TestRunnerServiceImplTest {
                     )
                 ]
             ).isNull()
-            //No screenshots for test3 either
+            // No screenshots for test3 either
             val testIdentifier3 = TestRunnerService.TestIdentifier(
                 className = "class2",
                 name = "name2",
@@ -508,7 +508,7 @@ class TestRunnerServiceImplTest {
                 screenshots3
             ).isEmpty()
         }
-        //check screenshots is null when list of testIdentifiers is empty
+        // check screenshots is null when list of testIdentifiers is empty
         val screenshots = subject.getTestMatrixResultsScreenshots(
             testMatrixId,
             emptyList()

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImplTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImplTest.kt
@@ -385,7 +385,7 @@ class TestRunnerServiceImplTest {
                 name = "name1",
                 runNumber = testRun.deviceRun.runNumber
             )
-            val screenshots1 = subject.getTestMatrixResultsScreenshots(
+            val screenshots1 = subject.getTestMatrixArtifacts(
                 testMatrixId,
                 listOf(testIdentifier1)
             )
@@ -477,7 +477,7 @@ class TestRunnerServiceImplTest {
                 name = "name2",
                 runNumber = testRun.deviceRun.runNumber
             )
-            val screenshots2 = subject.getTestMatrixResultsScreenshots(
+            val screenshots2 = subject.getTestMatrixArtifacts(
                 testMatrixId,
                 listOf(testIdentifier2)
             )
@@ -500,7 +500,7 @@ class TestRunnerServiceImplTest {
                 name = "name2",
                 runNumber = testRun.deviceRun.runNumber
             )
-            val screenshots3 = subject.getTestMatrixResultsScreenshots(
+            val screenshots3 = subject.getTestMatrixArtifacts(
                 testMatrixId,
                 listOf(testIdentifier3)
             )
@@ -509,7 +509,7 @@ class TestRunnerServiceImplTest {
             ).isEmpty()
         }
         // check screenshots is null when list of testIdentifiers is empty
-        val screenshots = subject.getTestMatrixResultsScreenshots(
+        val screenshots = subject.getTestMatrixArtifacts(
             testMatrixId,
             emptyList()
         )
@@ -807,7 +807,7 @@ class TestRunnerServiceImplTest {
             "name1",
             0
         )
-        val screenshots = subject.getTestMatrixResultsScreenshots(
+        val screenshots = subject.getTestMatrixArtifacts(
             testMatrixId,
             listOf(testIdentifier)
         )


### PR DESCRIPTION
Missed a check for empty list of testIdentifiers while getting screenshot files which caused this error:

https://pantheon.corp.google.com/logs/query;cursorTimestamp=2023-05-09T23:00:26.986202570Z;query=severity%3DERROR%0Atimestamp%3D%222023-05-09T23:00:26.986202570Z%22%0AinsertId%3D%221y2a8qeo4u45%22;timeRange=2023-05-09T22:40:30.000Z%2F2023-05-09T23:00:30.000Z?project=androidx-dev-prod

`java.util.NoSuchElementException: List is empty.
    at kotlin.collections.CollectionsKt___CollectionsKt.first(_Collections.kt:214)
    at dev.androidx.ci.testRunner.TestRunnerServiceImpl.findScreenshotFiles(TestRunnerServiceImpl.kt:219)
    at dev.androidx.ci.testRunner.TestRunnerServiceImpl.getTestMatrixResultsScreenshots(TestRunnerServiceImpl.kt:275)
    at androidx.aosp.ftl.FTLController.getScreenshots(FTLController.kt:254)
    at androidx.aosp.ftl.FTLController$getScreenshots$1.invokeSuspend(FTLController.kt)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
    at java.base/java.lang.Thread.run(Thread.java:1589)`

Adding a check to prevent this error.