### PR TITLE
Don't re-use bad test matrices

### DIFF
--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestMatrixStore.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestMatrixStore.kt
@@ -84,8 +84,16 @@ internal class TestMatrixStore(
         }
 
         getExistingTestMatrix(testRunId)?.let {
-            logger.info("found existing test matrix: ${it.testMatrixId}")
-            return it
+            logger.info("found existing test matrix: ${it.testMatrixId} with state: ${it.state}")
+            val state = it.state
+            // these states are ordered so anything above ERROR is not worth re-using
+            if (state != null && state >= TestMatrix.State.ERROR) {
+                logger.warn {
+                    "Skipping cache for ${it.testMatrixId} because its state is $state"
+                }
+            } else {
+                return it
+            }
         }
         logger.trace {
             "No test run history for $testRunId, creating a new one."

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestMatrixStoreTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestMatrixStoreTest.kt
@@ -222,7 +222,7 @@ internal class TestMatrixStoreTest {
     }
 
     @Test
-    fun dontCacheInvalid() = runBlocking<Unit> {
+    fun dontReuseTestMatricesWithInfraFailures() = runBlocking<Unit> {
         val appApk = createFakeApk("app.pak")
         val testApk = createFakeApk("test.apk")
         val extraApk = createFakeApk("extra.apk")


### PR DESCRIPTION
This CL changes the TestMatrix re-use logic to skip test matrices which failed for an infra or bad configuration error.

Both of these error types have the possibility of being intermediate so it is best not to re-use them and instead try running them again.

Test: TestMatrixStoreTest