### PR TITLE
don't fail for skipped tests

### DIFF
--- a/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
+++ b/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
@@ -263,7 +263,7 @@ private class Cli : CliktCommand() {
                 AndroidDevice(
                     orientation = "portrait",
                     androidModelId = model.id,
-                    locale = "en",
+                    locale = "en_US",
                     androidVersionId = spec.sdk
                 )
             }

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/FirebaseTestLabController.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/FirebaseTestLabController.kt
@@ -63,7 +63,7 @@ internal class FirebaseTestLabController(
             ?: error("Cannot find supported version for $defaultModel in test device catalog: $catalog")
         listOf(
             AndroidDevice(
-                locale = "en",
+                locale = "en_US",
                 androidModelId = defaultModel.id,
                 androidVersionId = defaultModelVersion.toString(),
                 orientation = "portrait"

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/StatusReporter.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/StatusReporter.kt
@@ -51,8 +51,8 @@ internal class StatusReporter(
     suspend fun reportEnd(testResult: TestResult) {
         val newState = when {
             testResult is TestResult.IncompleteRun -> CommitInfo.State.ERROR
-            testResult.allTestsPassed -> CommitInfo.State.SUCCESS
-            else -> CommitInfo.State.FAILURE
+            testResult.hasFailedTest -> CommitInfo.State.FAILURE
+            else -> CommitInfo.State.SUCCESS
         }
         updateState(state = newState)
     }

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/vo/TestResult.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/vo/TestResult.kt
@@ -19,6 +19,7 @@ package dev.androidx.ci.testRunner.vo
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import dev.androidx.ci.generated.ftl.TestMatrix
+import dev.androidx.ci.generated.ftl.TestMatrix.OutcomeSummary.FAILURE
 import dev.androidx.ci.generated.ftl.TestMatrix.OutcomeSummary.SUCCESS
 import dev.zacsweers.moshix.reflect.MetadataKotlinJsonAdapterFactory
 
@@ -26,6 +27,8 @@ sealed class TestResult(
     val type: Type
 ) {
     abstract val allTestsPassed: Boolean
+
+    abstract val hasFailedTest: Boolean
 
     abstract val failureLog: String
 
@@ -35,6 +38,11 @@ sealed class TestResult(
         override val allTestsPassed: Boolean by lazy {
             matrices.none {
                 it.outcomeSummary != SUCCESS
+            }
+        }
+        override val hasFailedTest: Boolean by lazy {
+            matrices.any {
+                it.outcomeSummary == FAILURE
             }
         }
         override val failureLog: String
@@ -54,6 +62,8 @@ sealed class TestResult(
     ) : TestResult(Type.INCOMPLETE_RUN) {
         override val allTestsPassed: Boolean
             get() = false
+        override val hasFailedTest: Boolean
+            get() = true
         override val failureLog: String
             get() = buildString {
                 appendLine("FTL failed with an exception:")

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/StateReporterTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/StateReporterTest.kt
@@ -87,7 +87,11 @@ internal class StateReporterTest {
             projectId = "myProject",
             requestId = "requestId",
             testMatrix = matrix
-        )
+        ).let {
+            it.copy(
+                outcomeSummary = TestMatrix.OutcomeSummary.FAILURE
+            )
+        }
         reporter.reportEnd(
             TestResult.CompleteRun(matrices = listOf(failedTestMatrix))
         )


### PR DESCRIPTION
this CL changes the default behavior for the ci-action to not fail for skipped tests. I've also updated default locale to en_US to match androidx ifnra.

Test: TestRunnerTest