### PR TITLE
Add parameter to ignore fully skipped tests

### DIFF
--- a/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
+++ b/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
@@ -148,6 +148,14 @@ private class Cli : CliktCommand() {
         envvar = "ANDROIDX_TEST_SUITE_TAGS"
     )
 
+    val ignoreEmptyTestMatrices by option(
+        help = """
+            When set to true (default), the action will not fail when no tests
+            are run for a TestMatrix.
+        """.trimIndent(),
+        envvar = "ANDROIDX_IGNORE_EMPTY_TEST_MATRICES"
+    )
+
     override fun run() {
         logFile?.let(::configureLogger)
         val repoParts = githubRepository.split("/")
@@ -177,7 +185,8 @@ private class Cli : CliktCommand() {
                 bucketName = gcpBucketName,
                 bucketPath = gcpBucketPath,
                 useTestConfigFiles = useTestConfigFiles?.toBoolean() ?: false,
-                testSuiteTags = testSuiteTags?.split(',')?.map { it.trim() } ?: emptyList()
+                testSuiteTags = testSuiteTags?.split(',')?.map { it.trim() } ?: emptyList(),
+                ignoreEmptyTestMatrices = ignoreEmptyTestMatrices?.toBoolean() ?: true,
             )
             testRunner.runTests()
         }

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
   test-suite-tags:
     description: 'A comma separated list of test suite tags to be run. Only used if use-test-config-files is true'
     required: false
+  ignore-empty-test-matrices:
+    description: 'When set to true (default), test matrices which have 0 non-skipped tests are considered SKIPPED instead of FAILED (FTL default).'
+    required: false
 
 runs:
   using: "composite"


### PR DESCRIPTION
We have some test artifacts that have no non-skipped tests. This CL adds a new
action parameter that allows ignoring them.

When all test cases in an APK are skipped, FTL marks its outcome as FAILED instead
of SKIPPED. In this CL, we fix it back to SKIPPED if requested.

Test: TestRunnerTest