### PR TITLE
]fail action only if there are failed tests

### DIFF
--- a/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
+++ b/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
@@ -157,7 +157,8 @@ private class Cli : CliktCommand() {
         """.trimIndent(),
         envvar = "ANDROIDX_IGNORE_EMPTY_TEST_MATRICES"
     ).convert {
-        it.takeIf { it.isNotEmpty() }?.toBoolean() ?: true
+        if (it. isNullOrBlank()) true
+        else it.toBoolean()
     }.default(true)
 
     override fun run() {

--- a/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
+++ b/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
@@ -157,8 +157,12 @@ private class Cli : CliktCommand() {
         """.trimIndent(),
         envvar = "ANDROIDX_IGNORE_EMPTY_TEST_MATRICES"
     ).convert {
-        if (it. isNullOrBlank()) true
-        else it.toBoolean()
+        if (it.isNullOrBlank()) {
+            // default to true.
+            true
+        } else {
+            it.toBoolean()
+        }
     }.default(true)
 
     override fun run() {

--- a/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
+++ b/AndroidXCI/cli/src/main/kotlin/dev/androidx/ci/cli/Main.kt
@@ -17,6 +17,8 @@
 package dev.androidx.ci.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
@@ -154,7 +156,9 @@ private class Cli : CliktCommand() {
             are run for a TestMatrix.
         """.trimIndent(),
         envvar = "ANDROIDX_IGNORE_EMPTY_TEST_MATRICES"
-    )
+    ).convert {
+        it.takeIf { it.isNotEmpty() }?.toBoolean() ?: true
+    }.default(true)
 
     override fun run() {
         logFile?.let(::configureLogger)
@@ -186,13 +190,13 @@ private class Cli : CliktCommand() {
                 bucketPath = gcpBucketPath,
                 useTestConfigFiles = useTestConfigFiles?.toBoolean() ?: false,
                 testSuiteTags = testSuiteTags?.split(',')?.map { it.trim() } ?: emptyList(),
-                ignoreEmptyTestMatrices = ignoreEmptyTestMatrices?.toBoolean() ?: true,
+                ignoreEmptyTestMatrices = ignoreEmptyTestMatrices,
             )
             testRunner.runTests()
         }
         println(result.toJson())
         flushLogs()
-        if (result.allTestsPassed) {
+        if (!result.hasFailedTest) {
             exitProcess(0)
         } else {
             println("================= FAILURE LOG =================")

--- a/action.yml
+++ b/action.yml
@@ -62,3 +62,4 @@ runs:
         ANDROIDX_BUCKET_PATH: ${{ inputs.gcp-bucket-path }}
         ANDROIDX_USE_TEST_CONFIG_FILES: ${{ inputs.use-test-config-files }}
         ANDROIDX_TEST_SUITE_TAGS: ${{ inputs.test-suite-tags }}
+        ANDROIDX_IGNORE_EMPTY_TEST_MATRICES: ${{ inputs.ignore-empty-test-matrices }}


### PR DESCRIPTION
This Cl changes CLIMain to only fail if there are known failres and ignore skips.

Also, the prior CL missed passing the environment variable for this parameter, it is fixed in this CL.

Finally, i've updated GCP credentials rule to accept application credentials, which is very handy for local testing