### PR TITLE
Updating result storage path

### DIFF
--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunner.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunner.kt
@@ -85,7 +85,8 @@ class TestRunner internal constructor(
         datastoreApi = datastoreApi,
         firebaseTestLabApi = firebaseTestLabApi,
         toolsResultApi = toolsResultApi,
-        resultsGcsPrefix = googleCloudApi.getGcsPath("ftl/$targetRunId")
+        resultsGcsPrefix = googleCloudApi.getGcsPath("ftl/$targetRunId"),
+        googleCloudApi = googleCloudApi
     )
     private val apkStore = ApkStore(googleCloudApi)
     private val testLabController = FirebaseTestLabController(

--- a/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImpl.kt
+++ b/AndroidXCI/lib/src/main/kotlin/dev/androidx/ci/testRunner/TestRunnerServiceImpl.kt
@@ -47,7 +47,8 @@ internal class TestRunnerServiceImpl internal constructor(
         datastoreApi = datastoreApi,
         firebaseTestLabApi = firebaseTestLabApi,
         toolsResultApi = toolsResultApi,
-        resultsGcsPrefix = googleCloudApi.getGcsPath("aosp-ftl/$gcsResultPath")
+        resultsGcsPrefix = googleCloudApi.getGcsPath("aosp-ftl/$gcsResultPath"),
+        googleCloudApi = googleCloudApi
     )
     private val apkStore = ApkStore(googleCloudApi)
     private val testLabController = FirebaseTestLabController(

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/FirebaseTestLabControllerTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/FirebaseTestLabControllerTest.kt
@@ -36,7 +36,8 @@ internal class FirebaseTestLabControllerTest {
             datastoreApi = fakeBackend.datastoreApi,
             firebaseTestLabApi = fakeBackend.fakeFirebaseTestLabApi,
             toolsResultApi = fakeBackend.fakeToolsResultApi,
-            resultsGcsPrefix = GcsPath("gs://test-results")
+            resultsGcsPrefix = GcsPath("gs://test-results"),
+            googleCloudApi = fakeBackend.fakeGoogleCloudApi
         )
     )
 

--- a/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestMatrixStoreTest.kt
+++ b/AndroidXCI/lib/src/test/kotlin/dev/androidx/ci/testRunner/TestMatrixStoreTest.kt
@@ -17,8 +17,10 @@
 package dev.androidx.ci.testRunner
 
 import com.google.common.truth.Truth.assertThat
+import dev.androidx.ci.fake.FakeBackend
 import dev.androidx.ci.fake.FakeDatastore
 import dev.androidx.ci.fake.FakeFirebaseTestLabApi
+import dev.androidx.ci.fake.FakeGoogleCloudApi
 import dev.androidx.ci.fake.FakeToolsResultApi
 import dev.androidx.ci.gcloud.GcsPath
 import dev.androidx.ci.generated.ftl.AndroidDevice
@@ -37,15 +39,17 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
 internal class TestMatrixStoreTest {
-    val firebaseTestLabApi = FakeFirebaseTestLabApi()
-    val datastoreApi = FakeDatastore()
-    val toolsResultApi = FakeToolsResultApi()
+    private val firebaseTestLabApi = FakeFirebaseTestLabApi()
+    private val datastoreApi = FakeDatastore()
+    private val toolsResultApi = FakeToolsResultApi()
+    private val fakeBackend = FakeBackend()
     private val store = TestMatrixStore(
         firebaseProjectId = "p1",
         firebaseTestLabApi = firebaseTestLabApi,
         datastoreApi = datastoreApi,
         toolsResultApi = toolsResultApi,
-        resultsGcsPrefix = GcsPath("gs://test")
+        resultsGcsPrefix = GcsPath("gs://test"),
+        googleCloudApi = fakeBackend.fakeGoogleCloudApi
     )
 
     private val envMatrix1 = EnvironmentMatrix(


### PR DESCRIPTION
We create results storage path based on the testMatrix parameters. When we reject a cached TestMatrix because of its state(because of failures), the testRunId computed for the new TestMatrix remains the same and we end up overwriting the previous results. This used to be ok, since the results for previously cached testMatrix were not very meaningful.

With smart retries, we set flaky count to 0. So, when we reject a testMatrix now because of failures, only the primary run testResults xml gets overwritten. Other results from previous run stay the same, causing us to retrieve wrong testResults.

This change would ensure if testResults gcsPath is already existing in our gcloud bucket, we'll set the storage for the new testMatrix to a different value.